### PR TITLE
build ✨: support updating attachments with delete/undo, and unify API resource structure

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -14,6 +14,7 @@ final class PostController extends Controller
 {
     public function __construct(protected PostService $postService)
     {
+        //
     }
 
     public function store(StorePostRequest $request): RedirectResponse
@@ -25,7 +26,7 @@ final class PostController extends Controller
 
     public function update(UpdatePostRequest $request, Post $post): RedirectResponse
     {
-        $post->update($request->validated());
+        $this->postService->updatePostWithAttachments($post, $request->validated());
 
         return redirect()->route('dashboard')->with('success', 'Post updated');
     }

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -43,7 +43,7 @@ final class StorePostRequest extends FormRequest
         return [
             'body' => ['nullable', 'string', 'max:1024'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
-            'attachments' => ['array', 'max:15', new TotalFileSize(self::$maxTotalSize)],
+            'attachments' => ['sometimes', 'array', 'max:15', new TotalFileSize(self::$maxTotalSize)],
             'attachments.*' => ['file',
                 File::types(self::$extensions)->max(self::$maxFileSize / 1024),
             ],

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -4,10 +4,27 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Rules\TotalFileSize;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\File;
 
 final class UpdatePostRequest extends FormRequest
 {
+    public static array $extensions = [
+        'jpg', 'jpeg', 'png', 'gif', 'webp',
+        'doc', 'docx', 'pdf', 'csv', 'xls', 'xlsx',
+    ];
+
+    /**
+     * Maximum file size in bytes (100MB per file)
+     */
+    public static int $maxFileSize = 100 * 1024 * 1024;
+
+    /**
+     * Maximum total size for all files (1GB)
+     */
+    public static int $maxTotalSize = 1 * 1024 * 1024 * 1024;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -26,6 +43,12 @@ final class UpdatePostRequest extends FormRequest
         return [
             'body' => ['nullable', 'string', 'max:1024'],
             'user_id' => ['required', 'integer', 'exists:users,id'],
+            'attachments' => ['sometimes', 'array', 'max:15', new TotalFileSize(self::$maxTotalSize)],
+            'attachments.*' => ['file',
+                File::types(self::$extensions)->max(self::$maxFileSize / 1024),
+            ],
+            'deleted_attachment_ids' => ['sometimes', 'array'],
+            'deleted_attachment_ids.*' => ['numeric'],
         ];
     }
 }

--- a/app/Http/Resources/PostAttachmentResource.php
+++ b/app/Http/Resources/PostAttachmentResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final class PostAttachmentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var Media $media */
+        $media = $this->resource;
+
+        return [
+            'id' => $media->id,
+            'uuid' => $media->uuid,
+            'name' => $media->name,
+            'file_name' => $media->file_name,
+            'mime_type' => $media->mime_type,
+            'size' => $media->size,
+            'url' => $media->getUrl(),
+            'preview_url' => $media->original_url,
+            'is_image' => str_starts_with($media->mime_type, 'image/'),
+            'human_readable_size' => $this->formatBytes($media->size),
+        ];
+    }
+
+    private function formatBytes(int $size): string
+    {
+        $base = log($size, 1024);
+        $suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+        return round(pow(1024, $base - floor($base)), 2).' '.$suffixes[floor($base)];
+    }
+}

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -27,7 +27,7 @@ final class PostResource extends JsonResource
             'body' => $post->body,
             'updated_at' => $post->updated_at->format('Y-m-d H:i:s'),
             'user' => UserResource::make($post->user),
-            'attachments' => $post->attachments()
+            'attachments' => PostAttachmentResource::collection($post->attachments()),
         ];
     }
 }

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -1,24 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Models\Post;
-use App\Models\User;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
-class PostService
+final class PostService
 {
-    public function createPostWithAttachments(array $data): Post {
+    public function createPostWithAttachments(array $data): Post
+    {
         return DB::transaction(function () use ($data) {
-           $post = Post::create($data);
+            $post = Post::create($data);
 
-           $this->handleAttachments($post, $data['attachments'] ?? []);
+            $this->handleAttachments($post, $data['attachments'] ?? []);
 
-           return $post;
+            return $post;
         });
     }
 
-    protected function handleAttachments(Post $post, array $files): void
+    public function updatePostWithAttachments(Post $post, array $data)
+    {
+        return DB::transaction(function () use ($post, $data) {
+           if (!empty($data['deleted_attachment_ids'])) {
+               foreach ($data['deleted_attachment_ids'] as $mediaId) {
+                   $media = $post->attachments()->find($mediaId);
+                   if ($media) {
+                       $media->delete();
+                   }
+               }
+           }
+
+           $this->handleAttachments($post, $data['attachments'] ?? []);
+
+            $post->update(
+                Arr::except($data, ['attachments', 'deleted_attachments_ids'])
+            );
+
+            return $post;
+        });
+    }
+
+    private function handleAttachments(Post $post, array $files): void
     {
         foreach ($files as $file) {
             $post->addMedia($file)->toMediaCollection('attachments');

--- a/resources/js/Components/app/PostAttachments.vue
+++ b/resources/js/Components/app/PostAttachments.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
 import {PaperClipIcon} from "@heroicons/vue/24/solid/index.js";
 import {computed} from "vue";
-
-interface Attachment {
-    uuid: string
-    name: string
-    file_name: string
-    original_url: string
-    preview_url: string
-    extension: string
-    size: number
-    order: number
-    custom_properties: any[]
-}
+import {Attachment} from "@/types/attachment";
 
 const props = defineProps<{
-    attachments: Record<string, Attachment>
+    attachments: Attachment[]
 }>()
 
 const attachmentList = computed(() => Object.values(props.attachments))
-
-const isImage = (attachment: Attachment): boolean => {
-    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(
-        attachment.extension.toLowerCase()
-    )
-}
 </script>
 
 <template>
@@ -34,8 +17,8 @@ const isImage = (attachment: Attachment): boolean => {
                 +{{ attachmentList.length - 4 }} more
             </div>
 
-            <img v-if="isImage(attachment)"
-                 :src="attachment.original_url"
+            <img v-if="attachment.is_image"
+                 :src="attachment.preview_url"
                  alt="attachment"
                  class="object-contain aspect-square"/>
             <div v-else class="flex flex-col justify-center items-center">

--- a/resources/js/types/attachment.ts
+++ b/resources/js/types/attachment.ts
@@ -1,0 +1,13 @@
+export interface Attachment {
+    id: number;
+    uuid: string;
+    name: string;
+    file_name: string;
+    mime_type: string;
+    size: number;
+    url: string;
+    preview_url: string;
+    is_image: boolean;
+    human_readable_size: string;
+    deleted ?: boolean
+}

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -1,4 +1,5 @@
 import {User} from "@/types/index";
+import {Attachment} from "@/types/attachment";
 
 export interface Post {
     id?: number;
@@ -6,5 +7,5 @@ export interface Post {
     user ?: User;
     user_id: number;
     updated_at: string;
-    attachments: Object
+    attachments: Attachment[]
 }


### PR DESCRIPTION
### What
- Enabled full support for updating post attachments:
  - Display existing attachments in the post update modal.
  - Allow users to **remove existing attachments** with an **undo** option.
  - Support adding new attachments during update.
- Unified the attachment definition across:
  - API resources
  - TypeScript interfaces
- Defined `UpdatePostRequest` and moved update logic to the `PostService` for a cleaner controller.
- Applied the `sometimes` validation rule for the attachments array.

### Why
- Improves UX when editing posts with media.
- Keeps the codebase DRY and consistent by centralizing attachment handling.
- Enhances validation and separation of concerns (service vs. controller).