### PR TITLE
refactor 🧩: lift edit/delete modals into PostList

### DIFF
--- a/resources/js/Components/app/PostItem.vue
+++ b/resources/js/Components/app/PostItem.vue
@@ -4,30 +4,16 @@ import {ChatBubbleLeftRightIcon, HandThumbUpIcon} from '@heroicons/vue/24/outlin
 import {Post} from "@/types/post";
 import PostHeader from "@/Components/app/PostHeader.vue";
 import EditDeleteDropdown from "@/Components/app/EditDeleteDropdown.vue";
-import {useForm} from "@inertiajs/vue3";
-import {ref} from "vue";
-import Modal from "@/Components/Modal.vue";
-import SecondaryButton from "@/Components/SecondaryButton.vue";
-import DangerButton from "@/Components/DangerButton.vue";
-import PostModal from "@/Components/app/PostModal.vue";
 import PostAttachments from "@/Components/app/PostAttachments.vue";
 
-const props = defineProps<{
+defineProps<{
     post: Post
 }>()
 
-const showUpdatePostModal = ref(false);
-const confirmPostDeletion = ref(false);
-const form = useForm({});
-
-const destroy = () => {
-    form.delete(route('posts.destroy', props.post.id), {
-        onSuccess: () => {
-            confirmPostDeletion.value = false
-        },
-        preserveScroll: true
-    })
-}
+defineEmits<{
+    (e: 'update', post: Post): void
+    (e: 'destroy', post: Post): void
+}>()
 </script>
 
 <template>
@@ -37,8 +23,8 @@ const destroy = () => {
             <div class="flex items-center">
                 <EditDeleteDropdown
                     :post="post"
-                    @update="showUpdatePostModal = true"
-                    @delete="confirmPostDeletion = true"
+                    @update="$emit('update', post)"
+                    @delete="$emit('destroy', post)"
                 />
             </div>
         </div>
@@ -52,7 +38,7 @@ const destroy = () => {
         >
             <PostAttachments :attachments="post.attachments" />
         </div>
-        <Disclosure v-slot="{ open }">
+        <Disclosure>
             <div class="flex gap-2">
                 <button
                     class="text-gray-800 dark:text-gray-100 flex gap-1 items-center justify-center  rounded-lg py-2 px-4 flex-1"
@@ -71,35 +57,4 @@ const destroy = () => {
             </div>
         </Disclosure>
     </div>
-
-    <PostModal :post="post" :show="showUpdatePostModal" @close="showUpdatePostModal = false"/>
-    <Modal :show="confirmPostDeletion" @close="confirmPostDeletion = false">
-        <div class="p-6">
-            <h2
-                class="text-lg font-medium text-gray-900 dark:text-gray-100"
-            >
-                Are you sure you want to delete this post?
-            </h2>
-
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                Once your post is deleted, all of its resources and data
-                will be permanently deleted.
-            </p>
-
-            <div class="mt-6 flex justify-end">
-                <SecondaryButton @click="confirmPostDeletion = false">
-                    Cancel
-                </SecondaryButton>
-
-                <DangerButton
-                    class="ms-3"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                    @click="destroy"
-                >
-                    Delete post
-                </DangerButton>
-            </div>
-        </div>
-    </Modal>
 </template>

--- a/resources/js/Components/app/PostList.vue
+++ b/resources/js/Components/app/PostList.vue
@@ -1,14 +1,95 @@
 <script setup lang="ts">
 import PostItem from "@/Components/app/PostItem.vue";
 import {Post} from "@/types/post";
+import {ref} from "vue";
+import {useForm} from "@inertiajs/vue3";
+import PostModal from "@/Components/app/PostModal.vue";
+import Modal from "@/Components/Modal.vue";
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import DangerButton from "@/Components/DangerButton.vue";
 
 defineProps<{
     posts: Post[]
 }>()
+
+const selectedPost = ref<Post|null>(null);
+const showEditModal = ref(false);
+const showDeleteModal = ref(false);
+
+const openEditModal = (post: Post) => {
+    selectedPost.value = post;
+    showEditModal.value = true;
+}
+
+const openConfirmDeleteModal = (post: Post) => {
+    selectedPost.value = post;
+    showDeleteModal.value = true;
+}
+
+const destroy = () => {
+    if (! selectedPost.value) {
+        return;
+    }
+
+    const form = useForm({});
+    form.delete(route('posts.destroy', selectedPost.value.id), {
+        onSuccess: () => {
+            showDeleteModal.value = false;
+            selectedPost.value = null;
+        }
+    })
+}
+
+const closeEditModal = () => {
+    showEditModal.value  = false;
+    selectedPost.value   = null;
+}
+
+const closeDeleteModal = () => {
+    showDeleteModal.value  = false;
+    selectedPost.value   = null;
+}
 </script>
 
 <template>
     <div class="overflow-auto">
-        <PostItem v-for="post in posts" :post="post" />
+        <PostItem
+            v-for="post in posts"
+            :post="post"
+            @update="openEditModal"
+            @destroy="openConfirmDeleteModal"
+        />
+
+        <PostModal v-if="selectedPost"
+          :show="showEditModal"
+          :post="selectedPost"
+          @close="closeEditModal"
+        />
+
+        <Modal
+          :show="showDeleteModal"
+          @close="closeDeleteModal"
+        >
+            <div class="p-6">
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    Are you sure you want to delete this post?
+                </h2>
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    This action cannot be undone.
+                </p>
+
+                <div class="mt-6 flex justify-end">
+                    <SecondaryButton @click="closeDeleteModal">
+                        Cancel
+                    </SecondaryButton>
+                    <DangerButton
+                        class="ms-3"
+                        @click="destroy"
+                    >
+                        Delete post
+                    </DangerButton>
+                </div>
+            </div>
+        </Modal>
     </div>
 </template>


### PR DESCRIPTION
### What
- Lifted the edit and delete modals out of `PostItem.vue` into `PostList.vue`.
- Removed `PostModal` and delete-confirmation markup from `PostItem.vue`.
- `PostItem.vue` is now a pure presentational component that:
  - Displays post details.
  - Emits `edit` and `delete` events with the selected post payload.
- `PostList.vue` now:
  - Tracks the `selectedPost`.
  - Renders a single shared `PostModal` and delete modal.

### Why
- Follows best practices: Smart (container) vs. dumb (presentational) component separation.
- Simplifies the logic in `PostItem`, making it more reusable and testable.
- Avoids duplicated modal instances for each item.