### PR TITLE
feat 🚀: introduce PostAttachmentPreviewModal with wrap‑around navigation

### DIFF
--- a/resources/js/Components/app/PostAttachmentPreviewModal.vue
+++ b/resources/js/Components/app/PostAttachmentPreviewModal.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import {Attachment} from "@/types/attachment";
+import {
+    TransitionRoot,
+    TransitionChild,
+    Dialog,
+    DialogPanel,
+} from '@headlessui/vue'
+import {XMarkIcon, PaperClipIcon, ChevronLeftIcon, ChevronRightIcon} from '@heroicons/vue/24/solid'
+import {ref} from "vue";
+
+const props = defineProps<{
+    attachments: Attachment[],
+    index: number,
+    show: boolean
+}>()
+
+defineEmits<{
+    (e: 'close'): void
+}>()
+
+const currentIndex = ref(props.index);
+
+const previous = () => {
+    const len = props.attachments.length
+    currentIndex.value = (currentIndex.value - 1 + len) % len
+}
+
+const next = () => {
+    const len = props.attachments.length
+    currentIndex.value = (currentIndex.value + 1) % len
+}
+</script>
+
+<template>
+    <TransitionRoot appear :show="show" as="div">
+        <Dialog as="div" @close="$emit('close')" class="relative z-50">
+            <TransitionChild
+                as="template"
+                enter="duration-300 ease-out"
+                enter-from="opacity-0"
+                enter-to="opacity-100"
+                leave="duration-200 ease-in"
+                leave-from="opacity-100"
+                leave-to="opacity-0"
+            >
+                <div class="fixed inset-0 bg-black/25"/>
+            </TransitionChild>
+
+            <div class="fixed inset-0 overflow-y-auto">
+                <div
+                    class="h-screen w-screen"
+                >
+                    <TransitionChild
+                        as="template"
+                        class="w-full h-full"
+                        enter="duration-300 ease-out"
+                        enter-from="opacity-0 scale-95"
+                        enter-to="opacity-100 scale-100"
+                        leave="duration-200 ease-in"
+                        leave-from="opacity-100 scale-100"
+                        leave-to="opacity-0 scale-95"
+                    >
+                        <DialogPanel
+                            class="flex flex-col w-full transform overflow-hidden bg-slate-800  text-left align-middle shadow-xl transition-all"
+                        >
+                            <button @click="$emit('close')"
+                                    class="absolute right-3 top-3 w-10 h-10 rounded-full hover:bg-black/10 transition flex items-center justify-center text-gray-100 z-40">
+                                <XMarkIcon class="w-6 h-6 "/>
+                            </button>
+                            <div class="relative group h-full ">
+                                <div
+                                    @click="previous"
+                                    class="absolute opacity-0 group-hover:opacity-100 text-gray-100 cursor-pointer flex items-center w-12 h-full left-0 bg-black/5 z-30">
+                                    <ChevronLeftIcon class="w-12"/>
+                                </div>
+                                <div
+                                    @click="next"
+                                    class="absolute opacity-0 group-hover:opacity-100 text-gray-100 cursor-pointer flex items-center w-12 h-full right-0 bg-black/5 z-30">
+                                    <ChevronRightIcon class="w-12"/>
+                                </div>
+
+                                <div class="flex items-center justify-center w-full h-full p-3">
+                                    <img v-if="attachments[currentIndex].is_image"
+                                         :src="attachments[currentIndex].preview_url"
+                                         alt="attachment-preview"
+                                         class="max-w-full max-h-full"/>
+                                    <div v-else
+                                         class="p-32 flex flex-col justify-center items-center text-gray-100">
+                                        <PaperClipIcon class="w-10 h-10 mb-3"/>
+
+                                        <small>{{ attachments[currentIndex].name }}</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </DialogPanel>
+                    </TransitionChild>
+                </div>
+            </div>
+        </Dialog>
+    </TransitionRoot>
+</template>

--- a/resources/js/Components/app/PostAttachments.vue
+++ b/resources/js/Components/app/PostAttachments.vue
@@ -1,20 +1,23 @@
 <script setup lang="ts">
 import {PaperClipIcon} from "@heroicons/vue/24/solid/index.js";
-import {computed} from "vue";
 import {Attachment} from "@/types/attachment";
 
 const props = defineProps<{
     attachments: Attachment[]
 }>()
 
-const attachmentList = computed(() => Object.values(props.attachments))
+defineEmits<{
+    (e: 'preview'): void
+}>()
 </script>
 
 <template>
-    <div v-for="(attachment, index) of attachmentList.slice(0, 4)">
-        <div class="group aspect-square bg-blue-100 flex flex-col items-center justify-center text-gray-500 relative cursor-pointer">
-            <div v-if="index === 3 && attachmentList.length > 4" class="absolute left-0 top-0 right-0 bottom-0 z-10 bg-black/60 text-white flex items-center justify-center text-2xl">
-                +{{ attachmentList.length - 4 }} more
+    <div v-for="(attachment, index) of attachments.slice(0, 4)">
+        <div
+            @click="$emit('preview', index)"
+            class="group aspect-square bg-blue-100 flex flex-col items-center justify-center text-gray-500 relative cursor-pointer">
+            <div v-if="index === 3 && attachments.length > 4" class="absolute left-0 top-0 right-0 bottom-0 z-10 bg-black/60 text-white flex items-center justify-center text-2xl">
+                +{{ attachments.length - 4 }} more
             </div>
 
             <img v-if="attachment.is_image"

--- a/resources/js/Components/app/PostItem.vue
+++ b/resources/js/Components/app/PostItem.vue
@@ -6,14 +6,19 @@ import PostHeader from "@/Components/app/PostHeader.vue";
 import EditDeleteDropdown from "@/Components/app/EditDeleteDropdown.vue";
 import PostAttachments from "@/Components/app/PostAttachments.vue";
 
-defineProps<{
+const props = defineProps<{
     post: Post
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
     (e: 'update', post: Post): void
     (e: 'destroy', post: Post): void
+    (e: 'previewAttachments', post: Post, index: number): void
 }>()
+
+const openAttachmentPreview = (index: number) => {
+    emit('previewAttachments', props.post, index)
+}
 </script>
 
 <template>
@@ -36,7 +41,7 @@ defineEmits<{
                 post.attachments.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
             ]"
         >
-            <PostAttachments :attachments="post.attachments" />
+            <PostAttachments :attachments="post.attachments" @preview="openAttachmentPreview"/>
         </div>
         <Disclosure>
             <div class="flex gap-2">

--- a/resources/js/Components/app/PostList.vue
+++ b/resources/js/Components/app/PostList.vue
@@ -7,14 +7,17 @@ import PostModal from "@/Components/app/PostModal.vue";
 import Modal from "@/Components/Modal.vue";
 import SecondaryButton from "@/Components/SecondaryButton.vue";
 import DangerButton from "@/Components/DangerButton.vue";
+import PostAttachmentPreviewModal from "@/Components/app/PostAttachmentPreviewModal.vue";
 
 defineProps<{
     posts: Post[]
 }>()
 
 const selectedPost = ref<Post|null>(null);
+const selectedAttachmentIndex = ref({});
 const showEditModal = ref(false);
 const showDeleteModal = ref(false);
+const showPostAttachmentPreviewModal = ref(false);
 
 const openEditModal = (post: Post) => {
     selectedPost.value = post;
@@ -24,6 +27,12 @@ const openEditModal = (post: Post) => {
 const openConfirmDeleteModal = (post: Post) => {
     selectedPost.value = post;
     showDeleteModal.value = true;
+}
+
+const openPostAttachmentPreviewModal = (post: Post, index: number) => {
+    selectedPost.value = post;
+    selectedAttachmentIndex.value = index;
+    showPostAttachmentPreviewModal.value = true;
 }
 
 const destroy = () => {
@@ -49,6 +58,11 @@ const closeDeleteModal = () => {
     showDeleteModal.value  = false;
     selectedPost.value   = null;
 }
+
+const closeAttachmentsPreviewModal = () => {
+    showPostAttachmentPreviewModal.value = false;
+    selectedPost.value = null;
+}
 </script>
 
 <template>
@@ -58,6 +72,7 @@ const closeDeleteModal = () => {
             :post="post"
             @update="openEditModal"
             @destroy="openConfirmDeleteModal"
+            @preview-attachments="openPostAttachmentPreviewModal"
         />
 
         <PostModal v-if="selectedPost"
@@ -91,5 +106,13 @@ const closeDeleteModal = () => {
                 </div>
             </div>
         </Modal>
+
+        <PostAttachmentPreviewModal
+            v-if="selectedPost"
+            :attachments="selectedPost.attachments"
+            :index="selectedAttachmentIndex"
+            :show="showPostAttachmentPreviewModal"
+            @close="closeAttachmentsPreviewModal"
+        />
     </div>
 </template>


### PR DESCRIPTION
### What
- Introduced `PostAttachmentPreviewModal.vue` component:
  - Supports image and generic file preview (uses `PaperClipIcon` for non-images).
  - Implements `prev()` / `next()` navigation with wrap-around using modulo logic.
  - Uses `HeadlessUI`'s `Dialog` and `Transition` for accessible and smooth modal UI.

### Why
- Enhances user experience by allowing full-size previews of post attachments.
- Improves accessibility and interface consistency using HeadlessUI components.
- Wrap-around navigation ensures users can move through all attachments seamlessly.

### Notes
- Currently supports basic file types; future versions can support PDFs, videos, etc.
