### PR TITLE
build(post): validate attachment types and show user-friendly error messages

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StorePostRequest;
 use App\Http\Resources\PostResource;
 use App\Models\Post;
 use Illuminate\Http\Request;
@@ -21,6 +22,7 @@ final class HomeController extends Controller
 
         return Inertia::render('Home', [
             'feed' => PostResource::collection($posts),
+            'allowed_attachment_extensions' => StorePostRequest::$extensions,
         ]);
     }
 }

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -16,14 +16,14 @@ final class StorePostRequest extends FormRequest
     ];
 
     /**
-     * Maximum file size in bytes (100MB per file)
+     * Maximum file size in bytes (10MB per file)
      */
-    public static int $maxFileSize = 100 * 1024 * 1024;
+    public static int $maxFileSize = 10 * 1024 * 1024;
 
     /**
-     * Maximum total size for all files (1GB)
+     * Maximum total size for all files (150B)
      */
-    public static int $maxTotalSize = 1 * 1024 * 1024 * 1024;
+    public static int $maxTotalSize = 150 * 1024 * 1024;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -47,6 +47,13 @@ final class StorePostRequest extends FormRequest
             'attachments.*' => ['file',
                 File::types(self::$extensions)->max(self::$maxFileSize / 1024),
             ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'attachments.*.mimes' => 'Invalid file type.',
         ];
     }
 }

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -16,14 +16,14 @@ final class UpdatePostRequest extends FormRequest
     ];
 
     /**
-     * Maximum file size in bytes (100MB per file)
+     * Maximum file size in bytes (10MB per file)
      */
-    public static int $maxFileSize = 100 * 1024 * 1024;
+    public static int $maxFileSize = 10 * 1024 * 1024;
 
     /**
-     * Maximum total size for all files (1GB)
+     * Maximum total size for all files (150B)
      */
-    public static int $maxTotalSize = 1 * 1024 * 1024 * 1024;
+    public static int $maxTotalSize = 150 * 1024 * 1024;
 
     /**
      * Determine if the user is authorized to make this request.
@@ -49,6 +49,13 @@ final class UpdatePostRequest extends FormRequest
             ],
             'deleted_attachment_ids' => ['sometimes', 'array'],
             'deleted_attachment_ids.*' => ['numeric'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'attachments.*.mimes' => 'Invalid file type.',
         ];
     }
 }


### PR DESCRIPTION
### What
- Passed the allowed attachment types to the feed page.
- Displayed validation error messages for:
  - Invalid file extension.
  - File size exceeding the limit.
- Overwrote the default validation rule message for a more user-friendly error.
- Added visual feedback:
  - Inline error message for invalid attachments.
  - Tooltip/note listing supported file types when invalid types are detected.

### Why
- Prevents user frustration by validating attachments **before form submission**.
- Ensures users clearly understand what types of files are allowed.
- Enhances form UX by providing real-time feedback.