### PR TITLE
build(post): implement post reactions with toggle, eager-loading, and frontend integration

### DIFF
--- a/app/Enums/ReactionTypeEnum.php
+++ b/app/Enums/ReactionTypeEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ReactionTypeEnum: string
+{
+    case LIKE = 'like';
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -18,7 +18,8 @@ final class HomeController extends Controller
      */
     public function __invoke(Request $request): Response
     {
-        $posts = Post::with('user')->paginate(20);
+        $posts = Post::withCount('reactions')
+            ->with('user')->paginate(20);
 
         return Inertia::render('Home', [
             'feed' => PostResource::collection($posts),

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreReactionRequest;
+use App\Models\Post;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+final class ReactionController extends Controller
+{
+    public function __invoke(StoreReactionRequest $request, Post $post): JsonResponse
+    {
+        $data = $request->validated();
+        $user = Auth::user();
+        $existing = $post->reactions()
+            ->where('user_id', $user->id)
+            ->first();
+
+        if ($existing) {
+            $existing->delete();
+            $hasReaction = false;
+        } else {
+            $post->reactions()->create([
+                'user_id' => $user->id,
+                'type' => $data['type'],
+            ]);
+            $hasReaction = true;
+        }
+
+        return response()->json([
+            'num_of_reactions' => $post->reactions()->count(),
+            'current_user_has_reaction' => $hasReaction,
+        ]);
+    }
+}

--- a/app/Http/Requests/StoreReactionRequest.php
+++ b/app/Http/Requests/StoreReactionRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\ReactionTypeEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class StoreReactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::enum(ReactionTypeEnum::class)],
+        ];
+    }
+}

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -27,6 +27,8 @@ final class PostResource extends JsonResource
             'body' => $post->body,
             'updated_at' => $post->updated_at->format('Y-m-d H:i:s'),
             'user' => UserResource::make($post->user),
+            'num_of_reactions' => $this->reactions_count,
+            'user_has_reaction' => $this->reactions_count > 0,
             'attachments' => PostAttachmentResource::collection($post->attachments()),
         ];
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
@@ -31,6 +32,11 @@ final class Post extends Model implements HasMedia
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function reactions(): HasMany
+    {
+        return $this->hasMany(Reaction::class);
     }
 
     public function registerMediaCollections(): void

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class Reaction extends Model
+{
+    protected $fillable = ['user_id', 'post_id', 'type'];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -24,16 +24,16 @@ final class PostService
     public function updatePostWithAttachments(Post $post, array $data)
     {
         return DB::transaction(function () use ($post, $data) {
-           if (!empty($data['deleted_attachment_ids'])) {
-               foreach ($data['deleted_attachment_ids'] as $mediaId) {
-                   $media = $post->attachments()->find($mediaId);
-                   if ($media) {
-                       $media->delete();
-                   }
-               }
-           }
+            if (! empty($data['deleted_attachment_ids'])) {
+                foreach ($data['deleted_attachment_ids'] as $mediaId) {
+                    $media = $post->attachments()->find($mediaId);
+                    if ($media) {
+                        $media->delete();
+                    }
+                }
+            }
 
-           $this->handleAttachments($post, $data['attachments'] ?? []);
+            $this->handleAttachments($post, $data['attachments'] ?? []);
 
             $post->update(
                 Arr::except($data, ['attachments', 'deleted_attachments_ids'])

--- a/database/migrations/2025_07_27_090237_create_reactions_table.php
+++ b/database/migrations/2025_07_27_090237_create_reactions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained();
+            $table->foreignId('user_id')->constrained();
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reactions');
+    }
+};

--- a/resources/js/Components/app/PostItem.vue
+++ b/resources/js/Components/app/PostItem.vue
@@ -5,6 +5,8 @@ import {Post} from "@/types/post";
 import PostHeader from "@/Components/app/PostHeader.vue";
 import EditDeleteDropdown from "@/Components/app/EditDeleteDropdown.vue";
 import PostAttachments from "@/Components/app/PostAttachments.vue";
+import {ref} from "vue";
+import axios from "axios";
 
 const props = defineProps<{
     post: Post
@@ -16,8 +18,27 @@ const emit = defineEmits<{
     (e: 'previewAttachments', post: Post, index: number): void
 }>()
 
+const loading = ref(false)
+
 const openAttachmentPreview = (index: number) => {
     emit('previewAttachments', props.post, index)
+}
+
+const toggleReaction = () => {
+    loading.value = true;
+
+    axios.post(route('posts.reactions', props.post.id), {
+        type: 'like'
+    }).then((response) => {
+        const { num_of_reactions, current_user_has_reaction } = response.data;
+
+        props.post.num_of_reactions = num_of_reactions;
+        props.post.user_has_reaction = current_user_has_reaction;
+    }).catch(error => {
+        console.error('Reaction failed', error)
+    }).finally(() => {
+        loading.value = false;
+    })
 }
 </script>
 
@@ -46,10 +67,16 @@ const openAttachmentPreview = (index: number) => {
         <Disclosure>
             <div class="flex gap-2">
                 <button
+                    @click="toggleReaction"
                     class="text-gray-800 dark:text-gray-100 flex gap-1 items-center justify-center  rounded-lg py-2 px-4 flex-1"
+                    :class="[
+                    post.user_has_reaction ?
+                     'bg-sky-100 dark:bg-sky-900 hover:bg-sky-200 dark:hover:bg-sky-950' :
+                     'bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800']
+                     "
                 >
-                    <HandThumbUpIcon class="w-5 h-5"/>
-                    <span class="mr-2">55</span>
+                    <HandThumbUpIcon class="size-5"/>
+                    <span class="mr-2">{{ post.num_of_reactions }}</span>
                     Like
                 </button>
                 <DisclosureButton

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -7,5 +7,7 @@ export interface Post {
     user ?: User;
     user_id: number;
     updated_at: string;
+    num_of_reactions: number;
+    user_has_reaction: boolean;
     attachments: Attachment[]
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProfileImageController;
+use App\Http\Controllers\ReactionController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', HomeController::class)->middleware(['auth', 'verified'])->name('dashboard');
@@ -17,6 +18,7 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::resource('posts', PostController::class);
+    Route::post('posts/{post}/reactions', ReactionController::class)->name('posts.reactions');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### What
- Created the `reactions` table and `Reaction` model.
- Defined a `hasMany` / `belongsTo` relationship between `Post` and `Reaction`.
- Eager-loaded reactions with posts on the feed page and included them in API resources.
- Defined a `ReactionType` enum to support multiple types in the future.
- Implemented toggling reactions using:
  - An invokable `ReactionController`
  - A validated reaction request
  - A clean `POST` route in `web.php`
- Integrated frontend logic:
  - Send toggle reaction request per post
  - Render reaction state dynamically in the UI
- Applied code formatting using Laravel Pint.

### Why
- Adds interactivity to posts, improving engagement on the platform.
- Designed for future flexibility (e.g. emojis or reaction types beyond "like").