### PR TITLE
build(reactions): add comment reactions and render like state in UI

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreCommentRequest;
@@ -10,7 +12,7 @@ use App\Models\Post;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
-class CommentController extends Controller
+final class CommentController extends Controller
 {
     public function store(StoreCommentRequest $request, Post $post)
     {
@@ -24,6 +26,7 @@ class CommentController extends Controller
         $data['user_id'] = $user->id;
 
         $comment = Comment::create($data);
+
         return response(CommentResource::make($comment), 201);
     }
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -19,7 +19,13 @@ final class HomeController extends Controller
     public function __invoke(Request $request): Response
     {
         $posts = Post::withCount('reactions')
-            ->with('user', 'comments', 'comments.user')->paginate(20);
+            ->with([
+                'user',
+                'reactionByCurrentUser',
+                'comments' => function ($query) {
+                    $query->withCount('reactions')->with('user', 'reactionByCurrentUser');
+                },
+            ])->paginate(20);
 
         return Inertia::render('Home', [
             'feed' => PostResource::collection($posts),

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -5,17 +5,24 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreReactionRequest;
+use App\Models\Comment;
 use App\Models\Post;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 final class ReactionController extends Controller
 {
-    public function __invoke(StoreReactionRequest $request, Post $post): JsonResponse
+    public function __invoke(StoreReactionRequest $request, ?Post $post = null, ?Comment $comment = null): JsonResponse
     {
-        $data = $request->validated();
+        $reactable = $post ?? $comment;
+
+        if (! $reactable) {
+            abort(404);
+        }
+
         $user = Auth::user();
-        $existing = $post->reactions()
+
+        $existing = $reactable->reactions()
             ->where('user_id', $user->id)
             ->first();
 
@@ -23,16 +30,16 @@ final class ReactionController extends Controller
             $existing->delete();
             $hasReaction = false;
         } else {
-            $post->reactions()->create([
+            $reactable->reactions()->create([
                 'user_id' => $user->id,
-                'type' => $data['type'],
+                'type' => $request->validated('type'),
             ]);
             $hasReaction = true;
         }
 
         return response()->json([
-            'num_of_reactions' => $post->reactions()->count(),
-            'current_user_has_reaction' => $hasReaction,
+            'num_of_reactions' => $reactable->reactions()->count(),
+            'user_has_reacted' => $hasReaction,
         ]);
     }
 }

--- a/app/Http/Requests/StoreCommentRequest.php
+++ b/app/Http/Requests/StoreCommentRequest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreCommentRequest extends FormRequest
+final class StoreCommentRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/UpdateCommentRequest.php
+++ b/app/Http/Requests/UpdateCommentRequest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class UpdateCommentRequest extends FormRequest
+final class UpdateCommentRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Resources;
 
 use App\Models\Comment;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class CommentResource extends JsonResource
+final class CommentResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -25,13 +27,15 @@ class CommentResource extends JsonResource
             'comment' => $comment->comment,
             'post_id' => $comment->post_id,
             'user_id' => $comment->user_id,
+            'num_of_reactions' => $this->reactions_count,
+            'user_has_reacted' => $this->relationLoaded('reactionByCurrentUser') && $this->reactionByCurrentUser !== null,
             'updated_at' => $comment->updated_at->format('Y-m-d H:i:s'),
             'user' => [
                 'id' => $comment->user->id,
                 'name' => $comment->user->name,
                 'username' => $comment->user->username,
-                'avatar_url' => $comment->user->getAvatarThumbUrlAttribute()
-            ]
+                'avatar_url' => $comment->user->getAvatarThumbUrlAttribute(),
+            ],
         ];
     }
 }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -29,9 +29,9 @@ final class PostResource extends JsonResource
             'updated_at' => $post->updated_at->format('Y-m-d H:i:s'),
             'user' => UserResource::make($post->user),
             'num_of_reactions' => $this->reactions_count,
-            'user_has_reaction' => $this->reactions_count > 0,
+            'user_has_reacted' => $this->relationLoaded('reactionByCurrentUser') && $this->reactionByCurrentUser !== null,
             'attachments' => PostAttachmentResource::collection($post->attachments()),
-            'comments' => $comments,
+            'comments' => CommentResource::collection($comments),
             'num_of_comments' => count($comments),
         ];
     }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @property-read int $id
@@ -14,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read DateTimeInterface $created_at
  * @property-read DateTimeInterface $updated_at
  */
-class Comment extends Model
+final class Comment extends Model
 {
     protected $fillable = ['post_id', 'user_id', 'comment'];
 
@@ -26,5 +31,17 @@ class Comment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function reactions(): MorphMany
+    {
+        return $this->morphMany(Reaction::class, 'reactable', 'object_type', 'object_id');
+    }
+
+    public function reactionByCurrentUser(): HasOne
+    {
+        return $this->hasOne(Reaction::class, 'object_id')
+            ->where('object_type', self::class)
+            ->where('user_id', Auth::id());
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,7 +8,9 @@ use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
@@ -38,6 +40,13 @@ final class Post extends Model implements HasMedia
     public function reactions(): MorphMany
     {
         return $this->morphMany(Reaction::class, 'reactable', 'object_type', 'object_id');
+    }
+
+    public function reactionByCurrentUser(): HasOne
+    {
+        return $this->hasOne(Reaction::class, 'object_id')
+            ->where('object_type', self::class)
+            ->where('user_id', Auth::id());
     }
 
     public function comments(): HasMany

--- a/app/Models/Reaction.php
+++ b/app/Models/Reaction.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  */
 final class Reaction extends Model
 {
-    protected $fillable = ['user_id', 'object_id', 'object_type', 'type'];
+    protected $fillable = ['user_id', 'type'];
 
     public function reactable(): MorphTo
     {

--- a/database/migrations/2025_07_27_094534_create_comments_table.php
+++ b/database/migrations/2025_07_27_094534_create_comments_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_07_27_114045_convert_reactions_table_to_polymorphic.php
+++ b/database/migrations/2025_07_27_114045_convert_reactions_table_to_polymorphic.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -18,7 +20,7 @@ return new class extends Migration
             $table->string('object_type')->after('object_id');
         });
 
-        DB::table('reactions')->update(['object_type' => \App\Models\Post::class]);
+        DB::table('reactions')->update(['object_type' => App\Models\Post::class]);
     }
 
     /**

--- a/resources/js/Components/app/CommentList.vue
+++ b/resources/js/Components/app/CommentList.vue
@@ -5,6 +5,9 @@ import {ref} from "vue";
 import axios from "axios";
 import EditDeleteDropdown from "@/Components/app/EditDeleteDropdown.vue";
 import SecondaryButton from "@/Components/SecondaryButton.vue";
+import {HandThumbUpIcon} from "@heroicons/vue/24/outline/index.js";
+import {Comment} from "@/types/comment";
+
 
 const props = defineProps<{
     post: Post
@@ -48,6 +51,17 @@ const destroy = (comment: Comment) => {
             props.post.comments.splice(index, 1);
             props.post.num_of_comments--;
         })
+}
+
+const toggleReaction = (comment: Comment) => {
+    axios.post(route('comments.reactions', comment.id), {
+        type: 'like'
+    }).then(({data}) => {
+        comment.num_of_reactions = data.num_of_reactions;
+        comment.user_has_reacted = data.user_has_reacted;
+    }).catch(error => {
+        console.error('Reaction failed', error)
+    })
 }
 </script>
 
@@ -113,7 +127,21 @@ const destroy = (comment: Comment) => {
                         class="flex items-center justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 relative w-[100px]">Update</button>
                 </div>
             </div>
-            {{comment.comment}}
+            <p>{{comment.comment}}</p>
+            <div class="mt-1 flex gap-2">
+                <button
+                    @click="toggleReaction(comment)"
+                        class="flex items-center text-xs text-indigo-500 py-0.5 px-1  rounded-lg"
+                    :class="[
+                        comment.user_has_reacted ?
+                         'bg-indigo-50 hover:bg-indigo-100' :
+                         'hover:bg-indigo-50'
+                    ]">
+                    <HandThumbUpIcon class="w-3 h-3 mr-1"/>
+                    <span class="mr-2">{{comment.num_of_reactions}}</span>
+                    Like
+                </button>
+            </div>
         </div>
     </div>
 </template>

--- a/resources/js/Components/app/PostItem.vue
+++ b/resources/js/Components/app/PostItem.vue
@@ -30,11 +30,9 @@ const toggleReaction = () => {
 
     axios.post(route('posts.reactions', props.post.id), {
         type: 'like'
-    }).then((response) => {
-        const { num_of_reactions, current_user_has_reaction } = response.data;
-
-        props.post.num_of_reactions = num_of_reactions;
-        props.post.user_has_reaction = current_user_has_reaction;
+    }).then(({data}) => {
+        props.post.num_of_reactions = data.num_of_reactions;
+        props.post.user_has_reacted = data.user_has_reacted;
     }).catch(error => {
         console.error('Reaction failed', error)
     }).finally(() => {
@@ -71,7 +69,7 @@ const toggleReaction = () => {
                     @click="toggleReaction"
                     class="text-gray-800 dark:text-gray-100 flex gap-1 items-center justify-center  rounded-lg py-2 px-4 flex-1"
                     :class="[
-                    post.user_has_reaction ?
+                    post.user_has_reacted ?
                      'bg-sky-100 dark:bg-sky-900 hover:bg-sky-200 dark:hover:bg-sky-950' :
                      'bg-gray-100 dark:bg-slate-900 dark:hover:bg-slate-800']
                      "

--- a/resources/js/types/comment.ts
+++ b/resources/js/types/comment.ts
@@ -6,5 +6,7 @@ export interface Comment {
     user_id: number;
     comment: string;
     updated_at: string;
-    user: User;
+    num_of_reactions: number;
+    user_has_reacted: boolean;
+    user?: User;
 }

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -10,7 +10,7 @@ export interface Post {
     updated_at: string;
     num_of_reactions: number;
     num_of_comments: number;
-    user_has_reaction: boolean;
+    user_has_reacted: boolean;
     comments: Comment[]
     attachments: Attachment[]
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,9 +23,10 @@ Route::middleware('auth')->group(function () {
         ->only(['store'])
         ->shallow();
     Route::resource('comments', CommentController::class)
-        ->only(['update','destroy']);
+        ->only(['update', 'destroy']);
 
     Route::post('posts/{post}/reactions', ReactionController::class)->name('posts.reactions');
+    Route::post('comments/{comment}/reactions', ReactionController::class)->name('comments.reactions');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### What
- Enabled adding reactions to comments using the polymorphic `Reaction` model.
- Defined `hasOne` relationships to determine if the **current user has reacted** to:
  - Posts
  - Comments
- Eager-loaded the `currentUserHasReaction` relation in the post feed to reduce query overhead.
- Updated the frontend:
  - Rendered the "like" button state dynamically based on whether the user has reacted.
  - Handled sending toggle reaction requests for comments.
  - Updated button styling to reflect reaction state.

### Why
- Brings full parity between posts and comments in terms of reaction functionality.
- Improves interactivity and user engagement.
- Cleanly integrates with the polymorphic structure introduced in previous PR.

### Notes
- Reaction types are currently limited (e.g., "like"), but easily extendable.