### PR TITLE
build(comment): add support for nested sub-comments and update UI rendering

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -23,7 +23,15 @@ final class HomeController extends Controller
                 'user',
                 'reactionByCurrentUser',
                 'comments' => function ($query) {
-                    $query->withCount('reactions')->with('user', 'reactionByCurrentUser');
+                    $query->whereNull('parent_id')
+                        ->withCount('reactions')
+                        ->with([
+                            'user',
+                            'reactionByCurrentUser',
+                            'replies' => function ($q) {
+                                $q->with('user', 'reactionByCurrentUser')->withCount('reactions');
+                            },
+                        ]);
                 },
             ])->paginate(20);
 

--- a/app/Http/Requests/StoreCommentRequest.php
+++ b/app/Http/Requests/StoreCommentRequest.php
@@ -25,6 +25,7 @@ final class StoreCommentRequest extends FormRequest
     {
         return [
             'comment' => ['required', 'string', 'max:255'],
+            'parent_id' => ['nullable', 'exists:comments,id'],
         ];
     }
 }

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -30,6 +30,8 @@ final class CommentResource extends JsonResource
             'num_of_reactions' => $this->reactions_count,
             'user_has_reacted' => $this->relationLoaded('reactionByCurrentUser') && $this->reactionByCurrentUser !== null,
             'updated_at' => $comment->updated_at->format('Y-m-d H:i:s'),
+            'replies' => self::collection($this->whenLoaded('replies')),
+            'num_of_replies' => $this->replies->count(),
             'user' => [
                 'id' => $comment->user->id,
                 'name' => $comment->user->name,

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\Auth;
  */
 final class Comment extends Model
 {
-    protected $fillable = ['post_id', 'user_id', 'comment'];
+    protected $fillable = ['post_id', 'user_id', 'comment', 'parent_id'];
 
     public function post(): BelongsTo
     {
@@ -43,5 +43,15 @@ final class Comment extends Model
         return $this->hasOne(Reaction::class, 'object_id')
             ->where('object_type', self::class)
             ->where('user_id', Auth::id());
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(self::class, 'parent_id')->with('user', 'replies');
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
     }
 }

--- a/database/migrations/2025_07_28_101414_add_parent_id_column_to_comments_table.php
+++ b/database/migrations/2025_07_28_101414_add_parent_id_column_to_comments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('parent_id')->nullable()->constrained('comments')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/js/Components/app/PostItem.vue
+++ b/resources/js/Components/app/PostItem.vue
@@ -88,7 +88,10 @@ const toggleReaction = () => {
             </div>
 
             <DisclosurePanel class="mt-5 max-h-[400px] overflow-auto">
-                <CommentList :post="post" />
+                <CommentList
+                    :post="post"
+                    :data="{comments: post.comments}"
+                />
             </DisclosurePanel>
         </Disclosure>
     </div>

--- a/resources/js/types/comment.ts
+++ b/resources/js/types/comment.ts
@@ -8,5 +8,7 @@ export interface Comment {
     updated_at: string;
     num_of_reactions: number;
     user_has_reacted: boolean;
+    replies?: Comment[],
+    num_of_replies?: number;
     user?: User;
 }


### PR DESCRIPTION
### What
- Added a `parent_id` column to the `comments` table to support nested (threaded) comments.
- Updated `PostComment` model with:
  - `replies()` relation (`hasMany` for children)
  - `parent()` relation (`belongsTo` for parent comment)
- Eager-loaded sub-comments (replies) for each top-level comment.
- Updated `CommentResource` to return nested replies in the API response.
- Modified the `StoreCommentRequest` to accept and validate the `parent_id`, ensuring it exists in the comments table.
- Updated the frontend `CommentList` and rendering logic to:
  - Display sub-comments nested under their parent.
  - Maintain clean visual hierarchy and structure.