### PR TITLE
build(reactions): refactor reaction logic into reusable interface and trait

### DIFF
--- a/app/Contracts/Reactable.php
+++ b/app/Contracts/Reactable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+interface Reactable
+{
+    public function reactions(): MorphMany;
+
+    public function toggleReactionForUser(int $userId, string $type): bool;
+
+    public function hasReactionFromUser(int $userId): bool;
+
+    public function getReactionCountAttribute(): int;
+}

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -4,42 +4,44 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Contracts\Reactable;
 use App\Http\Requests\StoreReactionRequest;
 use App\Models\Comment;
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 final class ReactionController extends Controller
 {
     public function __invoke(StoreReactionRequest $request, ?Post $post = null, ?Comment $comment = null): JsonResponse
     {
-        $reactable = $post ?? $comment;
-
-        if (! $reactable) {
-            abort(404);
-        }
-
+        /**
+         * @var User $user
+         */
         $user = Auth::user();
+        $reactable = $this->getReactableFromRoute($post, $comment);
 
-        $existing = $reactable->reactions()
-            ->where('user_id', $user->id)
-            ->first();
-
-        if ($existing) {
-            $existing->delete();
-            $hasReaction = false;
-        } else {
-            $reactable->reactions()->create([
-                'user_id' => $user->id,
-                'type' => $request->validated('type'),
-            ]);
-            $hasReaction = true;
-        }
+        $hasReaction = $reactable->toggleReactionForUser(
+            $user->id,
+            $request->validated('type')
+        );
 
         return response()->json([
-            'num_of_reactions' => $reactable->reactions()->count(),
+            'num_of_reactions' => $reactable->reaction_count,
             'user_has_reacted' => $hasReaction,
         ]);
+    }
+
+    private function getReactableFromRoute(?Post $post, ?Comment $comment): Reactable
+    {
+        $reactable = $post ?? $comment;
+
+        if (! $reactable instanceof Reactable) {
+            abort(404, 'Reactable resource not found');
+        }
+
+        return $reactable;
     }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -4,24 +4,28 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Contracts\Reactable;
+use App\Traits\HasReactions;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * @property-read int $id
  * @property-read string $comment
  * @property-read int $user_id
  * @property-read int $post_id
+ * @property-read int $reaction_count
  * @property-read DateTimeInterface $created_at
  * @property-read DateTimeInterface $updated_at
  */
-final class Comment extends Model
+final class Comment extends Model implements Reactable
 {
+    use HasReactions;
+
     protected $fillable = ['post_id', 'user_id', 'comment', 'parent_id', 'depth'];
+
+    protected $appends = ['reactions_count'];
 
     public function post(): BelongsTo
     {
@@ -31,18 +35,6 @@ final class Comment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
-    }
-
-    public function reactions(): MorphMany
-    {
-        return $this->morphMany(Reaction::class, 'reactable', 'object_type', 'object_id');
-    }
-
-    public function reactionByCurrentUser(): HasOne
-    {
-        return $this->hasOne(Reaction::class, 'object_id')
-            ->where('object_type', self::class)
-            ->where('user_id', Auth::id());
     }
 
     public function replies()

--- a/app/Traits/HasReactions.php
+++ b/app/Traits/HasReactions.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Models\Reaction;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+trait HasReactions
+{
+    public function reactions(): MorphMany
+    {
+        return $this->morphMany(Reaction::class, 'reactable', 'object_type', 'object_id');
+    }
+
+    public function toggleReactionForUser(int $userId, string $type): bool
+    {
+        $existingReaction = $this->reactions()->where('user_id', $userId)->first();
+
+        if ($existingReaction) {
+            $existingReaction->delete();
+
+            return false;
+        }
+
+        $this->reactions()->create([
+            'user_id' => $userId,
+            'type' => $type,
+        ]);
+
+        return true;
+    }
+
+    public function hasReactionFromUser(int $userId): bool
+    {
+        return $this->reactions()->where('user_id', $userId)->exists();
+    }
+
+    public function getReactionCountAttribute(): int
+    {
+        return $this->reactions()->count();
+    }
+}


### PR DESCRIPTION
### What
- Created a `Reactable` interface to define the contract for models that support reactions.
- Implemented a reusable `HasReactions` trait that provides:
  - Polymorphic relationship definition
  - Common utility methods (e.g., `hasUserReacted()`, `reactionCount()`)
- Refactored the `Post` and `Comment` models to:
  - Implement `Reactable`
  - Use `HasReactions` trait
- Updated the `ReactionController` to work with any `Reactable` model using a cleaner, polymorphic-based design.

### Why
- Promotes code reuse and clean architecture.
- Makes the reaction system easily extendable to future models (e.g. replies, articles).
- Reduces duplication in models and controllers.