### PR TITLE
feat(policies): add PostPolicy and CommentPolicy, expose permissions to frontend

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -10,7 +10,9 @@ use App\Http\Resources\CommentResource;
 use App\Models\Comment;
 use App\Models\Post;
 use App\Models\User;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 final class CommentController extends Controller
 {
@@ -43,15 +45,17 @@ final class CommentController extends Controller
         return response(CommentResource::make($comment), 201);
     }
 
-    public function update(UpdateCommentRequest $request, Comment $comment)
+    public function update(UpdateCommentRequest $request, Comment $comment): CommentResource
     {
+        Gate::authorize('update', $comment);
         $comment->update($request->validated());
 
         return CommentResource::make($comment);
     }
 
-    public function destroy(Comment $comment)
+    public function destroy(Comment $comment): Response
     {
+        Gate::authorize('delete', $comment);
         $comment->delete();
 
         return response()->noContent();

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\UpdatePostRequest;
 use App\Models\Post;
 use App\Services\PostService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
 
 final class PostController extends Controller
 {
@@ -26,6 +27,7 @@ final class PostController extends Controller
 
     public function update(UpdatePostRequest $request, Post $post): RedirectResponse
     {
+        Gate::authorize('update', $post);
         $this->postService->updatePostWithAttachments($post, $request->validated());
 
         return redirect()->route('dashboard')->with('success', 'Post updated');
@@ -33,6 +35,7 @@ final class PostController extends Controller
 
     public function destroy(Post $post): RedirectResponse
     {
+        Gate::authorize('delete', $post);
         $post->delete();
 
         return redirect()->route('dashboard')->with('success', 'Post deleted');

--- a/app/Http/Resources/CommentResource.php
+++ b/app/Http/Resources/CommentResource.php
@@ -8,6 +8,7 @@ use App\Models\Comment;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 final class CommentResource extends JsonResource
 {
@@ -40,6 +41,10 @@ final class CommentResource extends JsonResource
                 'username' => $comment->user->username,
                 'avatar_url' => $comment->user->getAvatarThumbUrlAttribute(),
             ],
+            'can' => [
+                'update' => Gate::allows('update', $comment),
+                'delete' => Gate::allows('delete', $comment),
+            ]
         ];
     }
 }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -8,6 +8,7 @@ use App\Models\Post;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 final class PostResource extends JsonResource
 {
@@ -34,6 +35,10 @@ final class PostResource extends JsonResource
             'attachments' => PostAttachmentResource::collection($post->attachments()),
             'comments' => CommentResource::collection($comments),
             'num_of_comments' => count($comments),
+            'can' => [
+                'update' => Gate::allows('update', $post),
+                'delete' => Gate::allows('delete', $post),
+            ]
         ];
     }
 }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+
+final class CommentPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id;
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+final class PostPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+}

--- a/resources/js/Components/app/EditDeleteDropdown.vue
+++ b/resources/js/Components/app/EditDeleteDropdown.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import {Post} from "@/types/post";
-import {usePage} from "@inertiajs/vue3";
 import {EllipsisVerticalIcon, PencilIcon, TrashIcon} from "@heroicons/vue/20/solid/index.js";
 import {Menu, MenuButton, MenuItem, MenuItems} from "@headlessui/vue";
 import {computed} from "vue";
-import {User} from "@/types";
 import {Comment} from "@/types/comment";
 
 const props = defineProps<{
@@ -17,11 +15,8 @@ defineEmits<{
     (e: 'delete'): void
 }>()
 
-const authUser = usePage().props.auth.user;
-const owner = computed<User>(() => props.post?.user || props.comment?.user);
-
-const editAllowed = computed(() => owner.value.id === authUser.id);
-const deleteAllowed = computed(() => owner.value.id === authUser.id);
+const canUpdate = computed(() => props.post?.can.update ?? props.comment?.can.update);
+const canDelete = computed(() => props.post?.can.delete ?? props.comment?.can.delete);
 </script>
 
 <template>
@@ -47,11 +42,10 @@ const deleteAllowed = computed(() => owner.value.id === authUser.id);
             leave-to-class="transform scale-95 opacity-0"
         >
             <MenuItems
-                v-if="authUser"
                 class="absolute z-20 right-0 mt-2 w-48 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none"
             >
                 <div class="px-1 py-1">
-                    <MenuItem v-if="editAllowed" v-slot="{ active }">
+                    <MenuItem v-if="canUpdate" v-slot="{ active }">
                         <button
                             @click="$emit('update')"
                             :class="[
@@ -65,7 +59,7 @@ const deleteAllowed = computed(() => owner.value.id === authUser.id);
                             Edit
                         </button>
                     </MenuItem>
-                    <MenuItem v-if="deleteAllowed" v-slot="{ active }">
+                    <MenuItem v-if="canDelete" v-slot="{ active }">
                         <button
                             @click="$emit('delete')"
                             :class="[

--- a/resources/js/types/comment.ts
+++ b/resources/js/types/comment.ts
@@ -12,4 +12,8 @@ export interface Comment {
     num_of_replies?: number;
     depth: number;
     user?: User;
+    can: {
+        update: boolean;
+        delete: boolean;
+    };
 }

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -12,5 +12,9 @@ export interface Post {
     num_of_comments: number;
     user_has_reacted: boolean;
     comments: Comment[]
-    attachments: Attachment[]
+    attachments: Attachment[],
+    can: {
+        update: boolean;
+        delete: boolean;
+    };
 }


### PR DESCRIPTION
### What
- Added `PostPolicy` and `CommentPolicy` to define authorization for:
  - `update`
  - `delete`
- Used `Gate::allows` within `PostResource` and `CommentResource` to expose permissions via a `can` object:
  ```json
  "can": {
    "update": true,
    "delete": false
  }
