### PR TITLE
build(groups): implement group creation with role enums, typed models, and modal UI

### DIFF
--- a/app/Enums/GroupUserRoleEnum.php
+++ b/app/Enums/GroupUserRoleEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum GroupUserRoleEnum: string
+{
+    case ADMIN = 'admin';
+    case USER = 'user';
+}

--- a/app/Enums/GroupUserStatusEnum.php
+++ b/app/Enums/GroupUserStatusEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum GroupUserStatusEnum: string
+{
+    case APPROVED = 'approved';
+    case PENDING = 'pending';
+}

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreGroupRequest;
+use App\Http\Resources\GroupResource;
+use App\Services\GroupService;
+use Illuminate\Support\Facades\Auth;
+
+final class GroupController extends Controller
+{
+    public function __construct(protected GroupService $groupService)
+    {
+        //
+    }
+
+    public function store(StoreGroupRequest $request)
+    {
+        $data = $request->validated();
+        $userId = Auth::id();
+
+        $group = $this->groupService->createGroupWithAdmin($data, $userId);
+
+        return response(GroupResource::make($group), 201);
+    }
+}

--- a/app/Http/Requests/StoreGroupRequest.php
+++ b/app/Http/Requests/StoreGroupRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class StoreGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:125'],
+            'auto_approval' => ['required', 'boolean'],
+            'about' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Group;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class GroupResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /**
+         * @var Group $group
+         */
+        $group = $this->resource;
+
+        return [
+            'id' => $group->id,
+            'name' => $group->name,
+            'slug' => $group->slug,
+            'auto_approval' => $group->auto_approval,
+            'about' => $group->about,
+            'user_id' => $group->user_id,
+            'created_at' => $group->created_at,
+            'updated_at' => $group->updated_at,
+        ];
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
+/**
+ * @property-read int $id
+ * @property-read string $name
+ * @property-read string $slug
+ * @property-read bool $auth_approval
+ * @property-read string $about
+ * @property-read int $user_id
+ * @property-read DateTimeInterface $created_at
+ * @property-read DateTimeInterface $updated_at
+ */
 final class Group extends Model
 {
     use HasSlug;

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -1,14 +1,38 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
+use App\Enums\GroupUserRoleEnum;
+use App\Enums\GroupUserStatusEnum;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class GroupUser extends Model
+/**
+ * @property-read int $id
+ * @property-read string $status
+ * @property-read string $role
+ * @property-read string $token
+ * @property-read DateTimeInterface $token_expires_at
+ * @property-read DateTimeInterface $token_used
+ * @property-read int $owner_id
+ * @property-read int $user_id
+ * @property-read int $group_id
+ * @property-read DateTimeInterface $created_at
+ */
+final class GroupUser extends Model
 {
+    public const UPDATED_AT = null;
+
     protected $fillable = [
-        'status', 'role', 'owner_id', 'user_id', 'group_id', 'token', 'token_expires_at'
+        'status', 'role', 'owner_id', 'user_id', 'group_id', 'token', 'token_expires_at',
+    ];
+
+    protected $casts = [
+        'status' => GroupUserStatusEnum::class,
+        'role' => GroupUserRoleEnum::class,
     ];
 
     public function owner(): BelongsTo

--- a/app/Services/GroupService.php
+++ b/app/Services/GroupService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\GroupUserRoleEnum;
+use App\Enums\GroupUserStatusEnum;
+use App\Models\Group;
+use App\Models\GroupUser;
+use Illuminate\Support\Facades\DB;
+
+final class GroupService
+{
+    public function createGroupWithAdmin(array $data, int $userId): Group
+    {
+        return DB::transaction(function () use ($data, $userId) {
+            $data['user_id'] = $userId;
+            $group = Group::create($data);
+
+            GroupUser::create([
+                'status' => GroupUserStatusEnum::APPROVED,
+                'role' => GroupUserRoleEnum::ADMIN,
+                'user_id' => $userId,
+                'group_id' => $group->id,
+                'owner_id' => $group->user_id,
+            ]);
+
+            return $group;
+        });
+    }
+}

--- a/database/migrations/2025_07_30_094417_create_groups_table.php
+++ b/database/migrations/2025_07_30_094417_create_groups_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name', 125);
             $table->string('slug', 125);
-            $table->boolean('auth_approval')->default(true);
+            $table->boolean('auto_approval')->default(true);
             $table->string('about', 255)->nullable();
             $table->foreignId('user_id')->constrained();
             $table->timestamps();

--- a/database/migrations/2025_07_30_095017_create_group_users_table.php
+++ b/database/migrations/2025_07_30_095017_create_group_users_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/resources/js/Components/app/GroupListItems.vue
+++ b/resources/js/Components/app/GroupListItems.vue
@@ -2,16 +2,19 @@
 import {ref} from "vue";
 import TextInput from "@/Components/TextInput.vue";
 import GroupItem from "@/Components/app/GroupItem.vue";
+import GroupModal from "@/Components/app/GroupModal.vue";
 
-const searchKeyword = ref('')
+const searchKeyword = ref('');
+const showGroupModal = ref(false);
 </script>
 
 <template>
     <div class="flex gap-2 mt-4">
         <TextInput :model-value="searchKeyword" placeholder="Type to search" class="w-full"/>
         <button
+            @click="showGroupModal = true"
                 class="text-sm bg-indigo-500 hover:bg-indigo-600 text-white rounded py-1 px-2 w-[120px]">
-            new group
+            New group
         </button>
     </div>
     <div class="mt-3 h-[200px] lg:flex-1 overflow-auto">
@@ -25,4 +28,6 @@ const searchKeyword = ref('')
             <GroupItem />
         </div>
     </div>
+
+    <GroupModal :show="showGroupModal" @close="showGroupModal = false"/>
 </template>

--- a/resources/js/Components/app/GroupModal.vue
+++ b/resources/js/Components/app/GroupModal.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import BaseModal from "@/Components/app/BaseModal.vue";
+import {XMarkIcon, BookmarkIcon} from '@heroicons/vue/24/solid'
+import TextInput from "@/Components/TextInput.vue";
+import {useForm} from "@inertiajs/vue3";
+import Checkbox from "@/Components/Checkbox.vue";
+import axios from "axios";
+
+defineProps<{
+    show: boolean
+}>()
+
+const emit = defineEmits<{
+    (e: 'close'): void
+}>()
+
+const form = useForm({
+    name: '',
+    auto_approval: true,
+    about: '',
+})
+
+const submit = () => {
+    axios.post(route('groups.store'), form)
+        .then((_) => {
+            emit('close')
+        })
+}
+</script>
+
+<template>
+    <BaseModal title="Create new Group" :show="show">
+        <div class="p-4 space-y-3 dark:text-gray-100">
+            <div>
+                <label>Group Name</label>
+                <TextInput
+                    v-model="form.name"
+                    type="text"
+                    class="mt-1 block w-full"
+                    autofocus
+                />
+            </div>
+
+            <div>
+                <label>
+                    <Checkbox name="remember" v-model:checked="form.auto_approval"/>
+                    Enable Auto Approval
+                </label>
+            </div>
+
+            <div>
+                <label>About Group</label>
+                <textarea
+                    v-model="form.about"
+                    class="dark:bg-slate-950 dark:text-white py-2 px-3 border-2 border-gray-200 dark:border-slate-900 text-gray-500 rounded-md mb-3 w-full resize-none"></textarea>
+            </div>
+        </div>
+
+        <div class="flex justify-end gap-2 py-3 px-4">
+            <button
+                @click="$emit('close')"
+                class="text-gray-800 flex gap-1 items-center justify-center bg-gray-100 rounded-md hover:bg-gray-200 py-2 px-4"
+            >
+                <XMarkIcon class="size-5"/>
+                Cancel
+            </button>
+            <button
+                @click="submit"
+                type="button"
+                class="flex items-center justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            >
+                <BookmarkIcon class="size-4 mr-2"/>
+                Submit
+            </button>
+        </div>
+    </BaseModal>
+</template>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\GroupController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PostAttachmentController;
 use App\Http\Controllers\PostController;
@@ -30,6 +31,8 @@ Route::middleware('auth')->group(function () {
 
     Route::post('posts/{post}/reactions', ReactionController::class)->name('posts.reactions');
     Route::post('comments/{comment}/reactions', ReactionController::class)->name('comments.reactions');
+
+    Route::resource('groups', GroupController::class);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### What
- Defined PHPDoc `@property-read` annotations in models for better IDE support and static analysis.
- Created enums for group-related metadata:
  - `GroupUserRole` (e.g., ADMIN, MEMBER)
  - `GroupUserStatus` (e.g., APPROVED, PENDING)
- Implemented logic for creating a group along with initial admin data in the pivot (`group_user`) table.
- Built a `GroupModal` Vue component to handle group creation in the UI.
- Applied Pint for consistent code formatting.

### Why
- Enums improve code clarity and reduce magic strings for roles and statuses.
- Ensures proper association between the group and the authenticated user as the initial admin.
- Introduces a clean and reusable frontend component for group creation.

### Notes
- Next step: add validation, editing, and inviting users to groups.
- Consider using policies to enforce group-level permissions in the future.