### PR TITLE
build(groups): define user-group relationships and expose role/status in resource

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StorePostRequest;
+use App\Http\Resources\GroupResource;
 use App\Http\Resources\PostResource;
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -19,6 +21,10 @@ final class HomeController extends Controller
      */
     public function __invoke(Request $request): Response
     {
+        /**
+         * @var User $user
+         */
+        $user = Auth::user();
         $userId = Auth::id();
 
         $posts = Post::with([
@@ -47,8 +53,16 @@ final class HomeController extends Controller
             ->latest()
             ->paginate(20);
 
+        $groups = $user
+            ->groups()
+            ->with('authUserMembership')
+            ->orderByPivot('role')
+            ->orderBy('name', 'desc')
+            ->get();
+
         return Inertia::render('Home', [
             'feed' => PostResource::collection($posts),
+            'groups' => GroupResource::collection($groups),
             'allowed_attachment_extensions' => StorePostRequest::$extensions,
         ]);
     }

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -29,6 +29,8 @@ final class GroupResource extends JsonResource
             'auto_approval' => $group->auto_approval,
             'about' => $group->about,
             'user_id' => $group->user_id,
+            'role' => $group->pivot?->role,
+            'status' => $group->pivot?->status,
             'created_at' => $group->created_at,
             'updated_at' => $group->updated_at,
         ];

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -6,6 +6,8 @@ namespace App\Models;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Auth;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -33,5 +35,10 @@ final class Group extends Model
             ->generateSlugsFrom('name')
             ->saveSlugsTo('slug')
             ->doNotGenerateSlugsOnUpdate();
+    }
+
+    public function authUserMembership(): HasOne
+    {
+        return $this->hasOne(GroupUser::class)->where('user_id', Auth::id());
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -93,6 +94,12 @@ final class User extends Authenticatable implements HasMedia
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class);
+    }
+
+    public function groups(): BelongsToMany
+    {
+        return $this->belongsToMany(Group::class, 'group_users')
+            ->withPivot(['status', 'role', 'owner_id']);
     }
 
     /**

--- a/app/Services/GroupService.php
+++ b/app/Services/GroupService.php
@@ -18,13 +18,15 @@ final class GroupService
             $data['user_id'] = $userId;
             $group = Group::create($data);
 
-            GroupUser::create([
+            $groupUser = GroupUser::create([
                 'status' => GroupUserStatusEnum::APPROVED,
                 'role' => GroupUserRoleEnum::ADMIN,
                 'user_id' => $userId,
                 'group_id' => $group->id,
                 'owner_id' => $group->user_id,
             ]);
+            
+            $group->setRelation('pivot', $groupUser);
 
             return $group;
         });

--- a/resources/js/Components/app/GroupItem.vue
+++ b/resources/js/Components/app/GroupItem.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
+import {Group} from "@/types/group";
 
+defineProps<{
+    group: Group
+}>()
 </script>
 
 <template>
     <div class="cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-800">
         <div class="flex items-start gap-1 py-2 px-2">
+            <img src="/img/no_image.png" alt="group-avatar" class="w-[32px] rounded-full"/>
             <div class="flex-1">
                 <div class="flex items-center justify-between">
-                    <h3 class="font-black">Group name</h3>
+                    <h3 class="font-black">{{ group.name }}</h3>
                 </div>
                 <span class="text-xs">
-                    approved
+                    {{ group.status === 'approved' ? (group.role === 'admin' ? group.role : '') : 'not approved' }}
                 </span>
             </div>
         </div>

--- a/resources/js/Components/app/GroupList.vue
+++ b/resources/js/Components/app/GroupList.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
 import GroupListItems from "@/Components/app/GroupListItems.vue";
+import {Group} from "@/types/group";
 
+defineProps<{
+    groups: Group[]
+}>()
 </script>
 
 <template>
@@ -19,7 +23,7 @@ import GroupListItems from "@/Components/app/GroupListItems.vue";
                     </div>
                 </DisclosureButton>
                 <DisclosurePanel>
-                    <GroupListItems/>
+                    <GroupListItems :groups="groups"/>
                 </DisclosurePanel>
             </Disclosure>
         </div>
@@ -27,7 +31,7 @@ import GroupListItems from "@/Components/app/GroupListItems.vue";
             <div class="flex justify-between">
                 <h2 class="text-xl font-bold">My Groups</h2>
             </div>
-            <GroupListItems/>
+            <GroupListItems :groups="groups"/>
         </div>
     </div>
 </template>

--- a/resources/js/Components/app/GroupListItems.vue
+++ b/resources/js/Components/app/GroupListItems.vue
@@ -3,9 +3,18 @@ import {ref} from "vue";
 import TextInput from "@/Components/TextInput.vue";
 import GroupItem from "@/Components/app/GroupItem.vue";
 import GroupModal from "@/Components/app/GroupModal.vue";
+import {Group} from "@/types/group";
 
 const searchKeyword = ref('');
 const showGroupModal = ref(false);
+
+const props = defineProps<{
+    groups: Group[]
+}>()
+
+const store = (group: Group): void => {
+    props.groups.unshift(group)
+}
 </script>
 
 <template>
@@ -22,12 +31,13 @@ const showGroupModal = ref(false);
             You are not joined to any groups
         </div>
         <div v-else>
-            <GroupItem />
-            <GroupItem />
-            <GroupItem />
-            <GroupItem />
+            <GroupItem v-for="group in groups" :group="group"/>
         </div>
     </div>
 
-    <GroupModal :show="showGroupModal" @close="showGroupModal = false"/>
+    <GroupModal
+        :show="showGroupModal"
+        @close="showGroupModal = false"
+        @store="store"
+    />
 </template>

--- a/resources/js/Components/app/GroupModal.vue
+++ b/resources/js/Components/app/GroupModal.vue
@@ -7,13 +7,15 @@ import Checkbox from "@/Components/Checkbox.vue";
 import axios from "axios";
 import InputError from "@/Components/InputError.vue";
 import {ref} from "vue";
+import {Group} from "@/types/group";
 
 defineProps<{
     show: boolean
 }>()
 
 const emit = defineEmits<{
-    (e: 'close'): void
+    (e: 'close'): void,
+    (e: 'store', group: Group): void
 }>()
 
 const form = useForm({
@@ -27,7 +29,8 @@ const loading = ref(false);
 const submit = () => {
     loading.value = true;
     axios.post(route('groups.store'), form)
-        .then((_) => {
+        .then(({data}) => {
+            emit('store', data)
             emit('close')
         })
         .catch((error) => {

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -6,15 +6,16 @@ import CreatePost from "@/Components/app/CreatePost.vue";
 import PostList from "@/Components/app/PostList.vue";
 import FollowingList from "@/Components/app/FollowingList.vue";
 import {Post} from "@/types/post";
-import {computed} from "vue";
+import {Group} from "@/types/group";
 
 const props = defineProps<{
     feed: {
         data: Post[]
+    },
+    groups: {
+        data: Group[]
     }
 }>()
-
-const posts = computed<Post[]>(() => props.feed.data);
 </script>
 
 <template>
@@ -23,14 +24,14 @@ const posts = computed<Post[]>(() => props.feed.data);
     <AuthenticatedLayout>
         <div class="grid lg:grid-cols-12 gap-3 p-4 h-full">
             <div class="lg:col-span-3 lg:order-1 h-full overflow-hidden">
-                <GroupList />
+                <GroupList :groups="groups.data"/>
             </div>
             <div class="lg:col-span-3 lg:order-3 h-full overflow-hidden">
                 <FollowingList />
             </div>
             <div class="lg:col-span-6 lg:order-2 h-full overflow-hidden flex flex-col">
                 <CreatePost />
-                <PostList :posts="posts"/>
+                <PostList :posts="feed.data"/>
             </div>
         </div>
     </AuthenticatedLayout>

--- a/resources/js/types/group.ts
+++ b/resources/js/types/group.ts
@@ -1,0 +1,12 @@
+export interface Group {
+    id: number;
+    name: string;
+    slug: string;
+    auto_approval: boolean;
+    about?: string;
+    user_id: number;
+    role: string;
+    status: string;
+    created_at: string;
+    updated_at: string;
+}


### PR DESCRIPTION
### What
- Defined relationships between `Group`, `User`, and the pivot model `GroupUser`:
- Eager-loaded the `group_user` pivot relationship after group creation.
- Updated `GroupResource` to include the current user's `role` and `status` via the pivot.
- Defined a `Group` interface on the frontend for type safety.
- Handled props passing in Vue and added the newly created group to the local `groups` list for instant UI feedback.

### Why
- Allows for flexible group management with per-user role and status data.
- Enhances API responses to support permission checks and UI state (e.g. pending approval, admin tools).
- Ensures frontend consistency and reactivity after group creation.