### PR TITLE
build(media): extract uploader service & support user/group avatar and cover updates

### DIFF
--- a/app/Http/Controllers/GroupImageController.php
+++ b/app/Http/Controllers/GroupImageController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateGroupImageRequest;
+use App\Models\Group;
+use App\Services\MediaUploadService;
+
+final class GroupImageController extends Controller
+{
+    public function __invoke(UpdateGroupImageRequest $request, Group $group, MediaUploadService $uploader): void
+    {
+        if ($file = $request->file('avatar_path')) {
+            $uploader->upload($group, 'avatar', $file);
+        }
+
+        if ($file = $request->file('cover_path')) {
+            $uploader->upload($group, 'cover', $file);
+        }
+    }
+}

--- a/app/Http/Controllers/ProfileImageController.php
+++ b/app/Http/Controllers/ProfileImageController.php
@@ -6,31 +6,18 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdateProfileImageRequest;
 use App\Models\User;
+use App\Services\MediaUploadService;
 
 final class ProfileImageController extends Controller
 {
-    public function update(UpdateProfileImageRequest $request, User $user)
+    public function __invoke(UpdateProfileImageRequest $request, User $user, MediaUploadService $uploader): void
     {
-        if ($request->hasFile('avatar_path')) {
-            $newAvatar = $request->file('avatar_path')->getClientOriginalName();
-            $oldAvatar = $user->getFirstMedia('avatar');
-
-            if (! $oldAvatar || $oldAvatar !== $newAvatar) {
-                $user->clearMediaCollection('avatar');
-                $user
-                    ->addMediaFromRequest('avatar_path')
-                    ->toMediaCollection('avatar', 'public');
-            }
+        if ($file = $request->file('avatar_path')) {
+            $uploader->upload($user, 'avatar', $file);
         }
 
-        if ($request->hasFile('cover_path')) {
-            $newCover = $request->file('cover_path')->getClientOriginalName();
-
-            $oldCover = $user->getFirstMedia('cover');
-            if (! $oldCover || $oldCover->file_name !== $newCover) {
-                $user->clearMediaCollection('cover');
-                $user->addMediaFromRequest('cover_path')->toMediaCollection('cover', 'public');
-            }
+        if ($file = $request->file('cover_path')) {
+            $uploader->upload($user, 'cover', $file);
         }
     }
 }

--- a/app/Http/Requests/UpdateGroupImageRequest.php
+++ b/app/Http/Requests/UpdateGroupImageRequest.php
@@ -6,7 +6,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-final class UpdateProfileImageRequest extends FormRequest
+final class UpdateGroupImageRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -31,6 +31,8 @@ final class GroupResource extends JsonResource
             'user_id' => $group->user_id,
             'role' => $group->pivot?->role,
             'status' => $group->pivot?->status,
+            'cover_url' => $group->getCoverUrlAttribute(),
+            'avatar_url' => $group->getAvatarThumbUrlAttribute(),
             'created_at' => $group->created_at,
             'updated_at' => $group->updated_at,
         ];

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -18,16 +19,21 @@ final class UserResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        /**
+         * @var User $user
+         */
+        $user = $this->resource;
+
         return [
-            'id' => $this->id,
-            'name' => $this->name,
-            'email' => $this->email,
-            'email_verified_at' => $this->email_verified_at,
-            'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
-            'username' => $this->username,
-            'cover_url' => $this->getCoverUrlAttribute(),
-            'avatar_url' => $this->getAvatarThumbUrlAttribute(),
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'email_verified_at' => $user->email_verified_at,
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+            'username' => $user->username,
+            'cover_url' => $user->getCoverUrlAttribute(),
+            'avatar_url' => $user->getAvatarThumbUrlAttribute(),
         ];
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -8,6 +8,8 @@ use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Auth;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -21,9 +23,9 @@ use Spatie\Sluggable\SlugOptions;
  * @property-read DateTimeInterface $created_at
  * @property-read DateTimeInterface $updated_at
  */
-final class Group extends Model
+final class Group extends Model implements HasMedia
 {
-    use HasSlug;
+    use HasSlug, InteractsWithMedia;
 
     protected $fillable = [
         'name', 'user_id', 'auto_approval', 'about',
@@ -35,6 +37,35 @@ final class Group extends Model
             ->generateSlugsFrom('name')
             ->saveSlugsTo('slug')
             ->doNotGenerateSlugsOnUpdate();
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection('avatar')
+            ->singleFile()
+            ->acceptsMimeTypes(['image/jpeg', 'image/png', 'image/webp']);
+
+        $this
+            ->addMediaCollection('cover')
+            ->singleFile()
+            ->acceptsMimeTypes(['image/jpeg', 'image/png', 'image/webp']);
+    }
+
+    /**
+     * Get avatar thumbnail URL
+     */
+    public function getAvatarThumbUrlAttribute(): ?string
+    {
+        return $this->getFirstMediaUrl('avatar');
+    }
+
+    /**
+     * Get cover URL
+     */
+    public function getCoverUrlAttribute(): ?string
+    {
+        return $this->getFirstMediaUrl('cover');
     }
 
     public function getRouteKeyName(): string

--- a/app/Services/GroupService.php
+++ b/app/Services/GroupService.php
@@ -25,7 +25,7 @@ final class GroupService
                 'group_id' => $group->id,
                 'owner_id' => $group->user_id,
             ]);
-            
+
             $group->setRelation('pivot', $groupUser);
 
             return $group;

--- a/app/Services/MediaUploadService.php
+++ b/app/Services/MediaUploadService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+use Spatie\MediaLibrary\HasMedia;
+
+final class MediaUploadService
+{
+    public function upload(HasMedia $model, string $collection, UploadedFile $file): void
+    {
+        $existing = $model->getFirstMedia($collection);
+
+        if ($existing && $existing->file_name === $file->getClientOriginalName()) {
+            return;
+        }
+
+        $model->clearMediaCollection($collection);
+        $model->addMedia($file)->toMediaCollection($collection, 'public');
+    }
+}

--- a/resources/js/Pages/Group/Show.vue
+++ b/resources/js/Pages/Group/Show.vue
@@ -6,18 +6,22 @@ import PrimaryButton from "@/Components/PrimaryButton.vue";
 import {Tab, TabGroup, TabList, TabPanel, TabPanels} from "@headlessui/vue";
 import TabItem from "@/Components/TabItem.vue";
 import {ref} from "vue";
-import {useForm} from "@inertiajs/vue3";
+import {Head, useForm} from "@inertiajs/vue3";
 
-defineProps<{
-    group: Group
+const props = defineProps<{
+    group: {
+        data: Group
+    }
 }>()
 
 const form = useForm<{
     avatar_path: File | null;
     cover_path: File | null;
+    _method: string
 }>({
     avatar_path: null,
     cover_path: null,
+    _method: 'PATCH'
 });
 
 const coverImageSrc = ref<string>('');
@@ -48,15 +52,32 @@ const onAvatarImageChange = (e: Event) => {
         reader.readAsDataURL(form.avatar_path);
     }
 }
+
+const reset = () => {
+    form.cover_path = null;
+    form.cover_path = null;
+    coverImageSrc.value = '';
+    avatarImageSrc.value = '';
+}
+
+const submit = () => {
+    form.post(route('groups.images.update', props.group.data.slug), {
+        onSuccess: () => {
+            reset();
+        }
+    })
+}
 </script>
 
 <template>
+    <Head title="Group Profile"/>
+
     <AuthenticatedLayout>
         <div class="max-w-[1100px] mx-auto h-full overflow-auto">
             <div class="px-4">
                 <div class="group relative bg-white dark:bg-slate-950 dark:text-gray-100">
                     <img
-                        :src="coverImageSrc || '/img/default_cover.jpg'"
+                        :src="group.data.cover_url || coverImageSrc || '/img/default_cover.jpg'"
                         alt="group-cover"
                         class="w-full h-[200px] object-cover"
                     />
@@ -84,6 +105,7 @@ const onAvatarImageChange = (e: Event) => {
                                 Cancel
                             </button>
                             <button
+                                @click="submit"
                                 class="bg-gray-800 hover:bg-gray-900 text-gray-100 py-1 px-2 text-xs flex items-center">
                                 <CheckCircleIcon class="h-3 w-3 mr-2"/>
                                 Submit
@@ -93,7 +115,7 @@ const onAvatarImageChange = (e: Event) => {
 
                     <div class="flex">
                         <div  class="flex items-center justify-center relative group/thumbnail -mt-[64px] ml-[48px] w-[128px] h-[128px] rounded-full">
-                            <img :src="avatarImageSrc || '/img/no_image.png'"
+                            <img :src="group.data.avatar_url || avatarImageSrc || '/img/no_image.png'"
                                  alt="avatar-image"
                                  class="w-full h-full object-cover rounded-full">
                             <button
@@ -111,6 +133,7 @@ const onAvatarImageChange = (e: Event) => {
                                     <XMarkIcon class="h-5 w-5"/>
                                 </button>
                                 <button
+                                    @click="submit"
                                     class="w-7 h-7 flex items-center justify-center bg-emerald-500/80 text-white rounded-full">
                                     <CheckCircleIcon class="h-5 w-5"/>
                                 </button>
@@ -118,7 +141,7 @@ const onAvatarImageChange = (e: Event) => {
                         </div>
 
                         <div class="flex justify-between items-center flex-1 p-4">
-                            <h2 class="font-bold text-lg">{{ group.name }}</h2>
+                            <h2 class="font-bold text-lg">{{ group.data.name }}</h2>
 
                             <PrimaryButton>Join To Group</PrimaryButton>
                         </div>

--- a/resources/js/types/group.ts
+++ b/resources/js/types/group.ts
@@ -7,6 +7,8 @@ export interface Group {
     user_id: number;
     role: string;
     status: string;
+    avatar_url ?: string;
+    cover_url ?: string;
     created_at: string;
     updated_at: string;
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\GroupController;
+use App\Http\Controllers\GroupImageController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PostAttachmentController;
 use App\Http\Controllers\PostController;
@@ -17,7 +18,7 @@ Route::get('/', HomeController::class)->middleware(['auth', 'verified'])->name('
 Route::middleware('auth')->group(function () {
     Route::get('/profile/{user:username}', [ProfileController::class, 'show'])->name('profile.show');
     Route::patch('/profile/{user}', [ProfileController::class, 'update'])->name('profile.update');
-    Route::patch('/profile/images/{user}', [ProfileImageController::class, 'update'])->name('profile.images.update');
+    Route::patch('/profile/images/{user}', ProfileImageController::class)->name('profile.images.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::get('/attachments/{media}/download', [PostAttachmentController::class, 'download'])->name('attachments.download');
@@ -33,6 +34,7 @@ Route::middleware('auth')->group(function () {
     Route::post('comments/{comment}/reactions', ReactionController::class)->name('comments.reactions');
 
     Route::resource('groups', GroupController::class);
+    Route::patch('/groups/images/{group}', GroupImageController::class)->name('groups.images.update');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### What
- Extracted media uploading logic into a reusable `MediaUploaderService`.
- Updated both `User` and `Group` models to use the media uploader for:
  - Avatar image upload
  - Cover image upload
- Applied `HasMedia` interface to the `Group` model.
- Defined upload rules for avatar and cover images (e.g., file size, type).
- Created routes and controller logic for updating group profile images.
- Extended API Resources to return:
  - `avatar_url`
  - `cover_url`
- Updated the Group profile UI to display the uploaded images.
- Refactored the `UserResource` to explicitly type-hint the `User` model.
- Code formatted using Laravel Pint.

### Why
- DRY principle: single responsibility and reusability for media uploads.
- Consistency across user and group profile image handling.
- Improves frontend responsiveness by updating image previews dynamically.