### PR TITLE
feat(groups): implement group joining logic with proper permission flags and UI updates

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -23,6 +23,10 @@ final class GroupController extends Controller
     {
         $group->load('authUserMembership');
 
+        if ($group->authUserMembership) {
+            $group->setRelation('pivot', $group->authUserMembership);
+        }
+
         return Inertia::render('Group/Show', [
             'group' => GroupResource::make($group),
         ]);

--- a/app/Http/Controllers/InviteUserController.php
+++ b/app/Http/Controllers/InviteUserController.php
@@ -38,6 +38,8 @@ final class InviteUserController extends Controller
             'owner_id' => Auth::id(),
         ]);
 
+        // TODO handle notifying the invited user
+
         return Inertia::render('Group/Show', [
             'success' => __('Invitation send to :email', [
                 'email' => $invitee->email,

--- a/app/Http/Controllers/JoinGroupController.php
+++ b/app/Http/Controllers/JoinGroupController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\GroupUserRoleEnum;
+use App\Enums\GroupUserStatusEnum;
+use App\Http\Requests\JoinGroupRequest;
+use App\Http\Resources\GroupResource;
+use App\Models\Group;
+use App\Models\GroupUser;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class JoinGroupController extends Controller
+{
+    /**
+     * Handle incoming request
+     */
+    public function __invoke(JoinGroupRequest $request, Group $group): Response
+    {
+        /**
+         * @var User $user
+         */
+        $user = Auth::user();
+
+        if ($group->auto_approval) {
+            $status = GroupUserStatusEnum::APPROVED;
+            $message = __('You have joined “:name”', ['name' => $group->name]);
+        } else {
+            $status = GroupUserStatusEnum::PENDING;
+            $message = __('Your request to join “:name” is pending approval', [
+                'name' => $group->name,
+            ]);
+        }
+
+        GroupUser::create([
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+            'status' => $status,
+            'role' => GroupUserRoleEnum::USER,
+            'owner_id' => $group->user_id,
+        ]);
+
+        return Inertia::render('Group/Show', [
+            'success' => $message,
+            'group' => GroupResource::make($group),
+        ]);
+    }
+}

--- a/app/Http/Requests/JoinGroupRequest.php
+++ b/app/Http/Requests/JoinGroupRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\GroupUser;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+final class JoinGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /**
+         * @var User $user
+         */
+        $user = Auth::user();
+        $group = $this->route('group');
+
+        $already = GroupUser::where([
+            'group_id' => $group->id,
+            'user_id' => $user->id,
+        ])->exists();
+
+        return $user && !$already;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -17,7 +17,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property-read int $id
  * @property-read string $name
  * @property-read string $slug
- * @property-read bool $auth_approval
+ * @property-read bool $auto_approval
  * @property-read string $about
  * @property-read int $user_id
  * @property-read DateTimeInterface $created_at

--- a/resources/js/Pages/Group/Show.vue
+++ b/resources/js/Pages/Group/Show.vue
@@ -70,11 +70,21 @@ const submit = () => {
         }
     })
 }
+
+const join = () => {
+    if (props.group.data.status === 'pending') {
+        return;
+    }
+
+    const form = useForm({});
+
+    form.post(route('groups.join', props.group.data.slug), {
+        preserveScroll: true
+    })
+}
 </script>
 
 <template>
-    <Head title="Group Profile"/>
-
     <AuthenticatedLayout>
         <div class="max-w-[1100px] mx-auto h-full overflow-auto">
             <div class="px-4">
@@ -152,7 +162,18 @@ const submit = () => {
                                 Invite Users
                             </PrimaryButton>
 
-                            <PrimaryButton v-else-if="group.data.can.join">
+                            <span
+                                v-if="group.data.status === 'pending'"
+                                class="text-sm italic text-gray-500"
+                            >
+                            Pending approval…
+                          </span>
+
+                            <PrimaryButton
+                                v-else-if="group.data.can.join"
+                                @click="join"
+                                :class="{'disabled:opacity-25 disabled:cursor-not-allowed': group.data.status === 'pending'}"
+                            >
                                 {{ group.data.auto_approval ? 'Join' : 'Request to join' }}
                             </PrimaryButton>
                         </div>
@@ -201,6 +222,8 @@ const submit = () => {
             </div>
         </div>
     </AuthenticatedLayout>
+
+    <Head title="Group Profile"/>
 
     <InviteUserToGroupModal
         :group="group.data"

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupImageController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InviteUserController;
+use App\Http\Controllers\JoinGroupController;
 use App\Http\Controllers\PostAttachmentController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
@@ -36,7 +37,13 @@ Route::middleware('auth')->group(function () {
 
     Route::resource('groups', GroupController::class);
     Route::patch('/groups/images/{group}', GroupImageController::class)->name('groups.images.update');
-    Route::post('groups/{group}/invite', InviteUserController::class)->name('groups.invite');
+
+    Route::prefix('groups/{group}')
+        ->name('groups.')
+        ->group(function () {
+            Route::post('join', JoinGroupController::class)->name('join');
+            Route::post('invite', InviteUserController::class)->name('invite');
+        });
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### What
- Fixed type declaration error for `auto_approval` property in the `Group` model.
- Fixed loading of `authUserMembership` relation to ensure correct membership state.
- Implemented backend logic for handling group join requests:
  - Supports auto-approval if enabled.
  - Tracks membership status otherwise.
- Updated the frontend UI to reflect join request status dynamically:
  - Show “Join” button if eligible.
  - Show “Pending” state when appropriate.

### Why
- Provides a secure and structured way for users to request group membership.
- Ensures the UI accurately represents the user’s membership status based on backend data.
- Lays the foundation for handling pending requests, approvals, and rejections in the future.

### Notes
- Future enhancements:
  - Ability for users to cancel a pending join request.
  - Admin approval workflow for non–auto-approved groups.
  - Notifications for group owners when new join requests are submitted.
