### PR TITLE
build(groups): render and retrieve approved group members

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -29,9 +29,11 @@ final class GroupController extends Controller
         }
 
         $pending = $group->pendingUsers()->get();
+        $users = $group->approvedUsers()->get();
 
         return Inertia::render('Group/Show', [
             'group' => GroupResource::make($group),
+            'users' => UserResource::collection($users),
             'pending' => UserResource::collection($pending),
         ]);
     }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -80,6 +80,12 @@ final class Group extends Model implements HasMedia
         return $this->hasOne(GroupUser::class)->where('user_id', Auth::id());
     }
 
+    public function approvedUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'group_users')
+            ->wherePivot('status', GroupUserStatusEnum::APPROVED->value);
+    }
+
     public function pendingUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'group_users')

--- a/resources/js/Components/app/UserListItem.vue
+++ b/resources/js/Components/app/UserListItem.vue
@@ -3,7 +3,8 @@ import {Link} from "@inertiajs/vue3"
 import {User} from "@/types";
 
 defineProps<{
-    user: User
+    user: User,
+    showApprovalActions: boolean
 }>()
 
 defineEmits<{
@@ -26,7 +27,7 @@ defineEmits<{
                 <Link :href="route('profile.show', user.username)">
                     <h3 class="font-black hover:underline">{{ user.name }}</h3>
                 </Link>
-                <div class="flex gap-1">
+                <div v-if="showApprovalActions" class="flex gap-1">
                     <button class="text-xs py-1 px-2 rounded bg-emerald-500 hover:bg-emerald-600 text-white"
                             @click="$emit('approve', user)">
                         Approve

--- a/resources/js/Pages/Group/Show.vue
+++ b/resources/js/Pages/Group/Show.vue
@@ -15,6 +15,9 @@ const props = defineProps<{
     group: {
         data: Group
     },
+    users: {
+        data: User[]
+    },
     pending: {
         data: User[]
     }
@@ -228,7 +231,12 @@ const response = (user: User, action: 'approve' | 'reject') => {
                             Posts
                         </TabPanel>
                         <TabPanel>
-                            Joined users
+                            <UserListItem
+                                v-for="user in users.data"
+                                :user="user"
+                                class="rounded-lg"
+                                :show-approval-actions="false"
+                            />
                         </TabPanel>
                         <TabPanel v-if="group.data.can.manage">
                             <div v-if="pending.data.length" class="grid grid-cols-2 gap-3">
@@ -236,6 +244,7 @@ const response = (user: User, action: 'approve' | 'reject') => {
                                     v-for="user in pending.data"
                                     :user="user"
                                     class="rounded-lg"
+                                    :show-approval-actions="true"
                                     @approve="response(user, 'approve')"
                                     @reject="response(user, 'reject')"
                                 />


### PR DESCRIPTION
### What
- Implemented backend logic to fetch only approved group members.
- Integrated the approved members list into the group frontend UI for rendering.

### Why
- Ensures only approved members are displayed to regular users, improving privacy and access control.
- Prevents pending or rejected users from appearing in the public member list.
- Supports a cleaner and more secure group management experience.

### Notes
- Consider paginating the approved members list if group sizes grow large.
- Additional role-based UI elements (e.g. badge for admins) can be added in future iterations.