### PR TITLE
fix(groups): retrieve only join-request pending users, not all pending ones

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -89,6 +89,7 @@ final class Group extends Model implements HasMedia
     public function pendingUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'group_users')
+            ->wherePivotNull('token')
             ->wherePivot('status', GroupUserStatusEnum::PENDING->value);
     }
 }


### PR DESCRIPTION
### What
- Refined the logic for fetching pending group users.
- Now retrieves only users who have explicitly requested to join the group.
- Excludes other types of pending statuses (e.g., invited but not accepted).

### Why
- Avoids confusion between invited users and those who actively requested to join.
- Ensures accurate representation of pending join requests in the group management UI.