### PR TITLE
build: support changing group member roles (admin, user)

### DIFF
--- a/app/Http/Controllers/ChangeUserRoleController.php
+++ b/app/Http/Controllers/ChangeUserRoleController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\GroupUserRoleEnum;
+use App\Models\Group;
+use App\Models\GroupUser;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ChangeUserRoleController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request, Group $group)
+    {
+        $data = $request->validate([
+            'user_id' => ['required'],
+            'role' => ['required', Rule::enum(GroupUserRoleEnum::class)],
+        ]);
+
+        $groupUser = GroupUser::where([
+            'user_id' => $data['user_id'],
+            'group_id' => $group->id,
+        ])->first();
+
+        if ($groupUser) {
+            $groupUser->update(['role' => $data['role']]);
+        }
+
+        return back();
+    }
+}

--- a/resources/js/Components/app/UserListItem.vue
+++ b/resources/js/Components/app/UserListItem.vue
@@ -4,12 +4,14 @@ import {User} from "@/types";
 
 defineProps<{
     user: User,
-    showApprovalActions: boolean
+    showApprovalActions: boolean,
+    showRoleChangeActions: boolean
 }>()
 
 defineEmits<{
     (e: 'approve', user: User): void,
-    (e: 'reject', user: User): void
+    (e: 'reject', user: User): void,
+    (e: 'changeRole', user: User, role: 'admin' | 'user')
 }>()
 </script>
 
@@ -35,6 +37,17 @@ defineEmits<{
                     <button class="text-xs py-1 px-2 rounded bg-red-500 hover:bg-red-600 text-white"
                             @click="$emit('reject', user)">
                         Reject
+                    </button>
+                </div>
+                <div v-if="showRoleChangeActions">
+                    <select
+                        @change="$emit('changeRole', user, $event.target.value)"
+                        class="rounded-md border-0 py-1 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 max-w-xs text-sm leading-6">
+                        <option :selected="user.role === 'admin'" value="admin">Admin</option>
+                        <option :selected="user.role === 'user'" value="user">User</option>
+                    </select>
+                    <button class="text-xs py-1.5 px-2 rounded bg-gray-700 hover:bg-gray-800 text-white ml-3 disabled:bg-gray-500">
+                        Delete
                     </button>
                 </div>
             </div>

--- a/resources/js/Pages/Group/Show.vue
+++ b/resources/js/Pages/Group/Show.vue
@@ -101,6 +101,17 @@ const response = (user: User, action: 'approve' | 'reject') => {
         preserveScroll: true
     })
 }
+
+const changeRole = (user: User, role: 'admin' | 'user') => {
+    const form = useForm({
+        user_id: user.id,
+        role: role
+    })
+
+    form.patch(route('groups.change-role', props.group.data.slug), {
+        preserveScroll: true
+    })
+}
 </script>
 
 <template>
@@ -231,12 +242,16 @@ const response = (user: User, action: 'approve' | 'reject') => {
                             Posts
                         </TabPanel>
                         <TabPanel>
-                            <UserListItem
-                                v-for="user in users.data"
-                                :user="user"
-                                class="rounded-lg"
-                                :show-approval-actions="false"
-                            />
+                            <div class="grid grid-cols-2 gap-3">
+                                <UserListItem
+                                    v-for="user in users.data"
+                                    :user="user"
+                                    class="rounded-lg"
+                                    :show-approval-actions="false"
+                                    :show-role-change-actions="group.data.can.manage && group.data.user_id !== user.id"
+                                    @change-role="changeRole"
+                                />
+                            </div>
                         </TabPanel>
                         <TabPanel v-if="group.data.can.manage">
                             <div v-if="pending.data.length" class="grid grid-cols-2 gap-3">
@@ -244,7 +259,8 @@ const response = (user: User, action: 'approve' | 'reject') => {
                                     v-for="user in pending.data"
                                     :user="user"
                                     class="rounded-lg"
-                                    :show-approval-actions="true"
+                                    :show-approval-actions="group.data.can.manage"
+                                    :show-role-change-actions="false"
                                     @approve="response(user, 'approve')"
                                     @reject="response(user, 'reject')"
                                 />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -9,6 +9,8 @@ export interface User {
     password ?: string;
     cover_url ?: string;
     avatar_url ?: string;
+    status ?: string;
+    role ?: string;
 }
 
 export type PageProps<

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\ApproveJoinRequestController;
+use App\Http\Controllers\ChangeUserRoleController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupImageController;
@@ -45,6 +46,7 @@ Route::middleware('auth')->group(function () {
             Route::post('join', JoinGroupController::class)->name('join');
             Route::post('invite', InviteUserController::class)->name('invite');
             Route::post('approve', ApproveJoinRequestController::class)->name('approve');
+            Route::patch('change-role', ChangeUserRoleController::class)->name('change-role');
         });
 });
 


### PR DESCRIPTION
### What
- Implemented backend logic to update a group member’s role between `admin` and `user`.
- Frontend now renders a `<select>` dropdown for each approved group member to modify their role.
- Emits role change event on selection and updates via API.

### Why
- Enables group owners to delegate permissions by promoting members to admins.
- Provides UI controls for dynamic role management without needing to leave the group page.

### Notes
- Consider disabling the role selector for self or other owners to prevent unintentional demotion.
- Future: support role change notifications or activity logs.