### PR TITLE
Build/groups

### DIFF
--- a/app/Http/Controllers/InviteUserController.php
+++ b/app/Http/Controllers/InviteUserController.php
@@ -9,6 +9,7 @@ use App\Enums\GroupUserStatusEnum;
 use App\Http\Requests\InviteUserRequest;
 use App\Models\Group;
 use App\Models\GroupUser;
+use App\Notifications\InvitationToGroup;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -36,7 +37,7 @@ final class InviteUserController extends Controller
             'owner_id' => Auth::id(),
         ]);
 
-        // TODO handle notifying the invited user
+        $invitee->notify(new InvitationToGroup($group->name, $hours));
 
         return back()->with('success',
             __('Invitation send to :email', [

--- a/app/Notifications/InvitationToGroup.php
+++ b/app/Notifications/InvitationToGroup.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class InvitationToGroup extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $groupName,
+        public int $expiresInHours
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => "You have been invited to join the group {$this->groupName}",
+            'expires_in' => $this->expiresInHours,
+            'group_name' => $this->groupName,
+        ];
+    }
+}

--- a/database/migrations/2025_08_04_173310_create_notifications_table.php
+++ b/database/migrations/2025_08_04_173310_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};


### PR DESCRIPTION
### What
- Created a new notifications migration table using Laravel's built-in notification system.
- Defined a new `InviteToGroup` notification class.
- Dispatched the notification when a group owner sends an invitation to a user.
- Notification is queued to avoid blocking the request lifecycle.

### Why
- Introduces a scalable and maintainable way to notify users about group invitations.
- Leverages Laravel's native notification system for future extensibility (email, database, broadcast, etc.).
- Offloads notification sending to the queue, improving app performance.

### Notes
- Consider adding real-time support via broadcasting (e.g., Pusher or Laravel WebSockets).
- Future feature: Add a notification center to the frontend to display unread alerts.
- This implementation assumes notifications will be delivered via database channel for now.