### PR TITLE
build: notify users when group join request is approved or role is changed

### DIFF
--- a/app/Http/Controllers/ApproveJoinRequestController.php
+++ b/app/Http/Controllers/ApproveJoinRequestController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers;
 use App\Enums\GroupUserStatusEnum;
 use App\Http\Requests\ApproveJoinRequest;
 use App\Models\Group;
+use App\Models\User;
+use App\Notifications\JoinRequestApproved;
 use Illuminate\Http\RedirectResponse;
 
 final class ApproveJoinRequestController extends Controller
@@ -18,6 +20,12 @@ final class ApproveJoinRequestController extends Controller
 
         if ($approved) {
             $groupUser->update(['status' => GroupUserStatusEnum::APPROVED]);
+
+            /**
+             * @var User $user
+             */
+            $user = $groupUser->user;
+            $user->notify(new JoinRequestApproved($group->name));
         } else {
             $groupUser->delete();
         }

--- a/app/Http/Controllers/ChangeUserRoleController.php
+++ b/app/Http/Controllers/ChangeUserRoleController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers;
 use App\Enums\GroupUserRoleEnum;
 use App\Models\Group;
 use App\Models\GroupUser;
+use App\Models\User;
+use App\Notifications\UserRoleChanged;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
@@ -29,6 +31,12 @@ final class ChangeUserRoleController extends Controller
 
         if ($groupUser) {
             $groupUser->update(['role' => $data['role']]);
+
+            /**
+             * @var User $user
+             */
+            $user = $groupUser->user;
+            $user->notify(new UserRoleChanged($group->name, $data['role']));
         }
 
         return back();

--- a/app/Notifications/JoinRequestApproved.php
+++ b/app/Notifications/JoinRequestApproved.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+final class JoinRequestApproved extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $groupName
+    ) {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => "Your request to join {$this->groupName} has been approved.",
+        ];
+    }
+}

--- a/app/Notifications/UserRoleChanged.php
+++ b/app/Notifications/UserRoleChanged.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UserRoleChanged extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $groupName,
+        public string $role
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => "Your role in this group {$this->groupName} has been changed to {$this->role}",
+        ];
+    }
+}


### PR DESCRIPTION
### What
- Sent a notification to users when their group join request is approved.
- Sent a notification when a group admin changes a user’s role (e.g., member → admin).
- Utilized Laravel's notification system with the database channel.
- Ensured notifications are queued for asynchronous delivery.

### Why
- Keeps users informed about important group-related changes.
- Improves transparency and engagement in group participation.
- Builds toward a complete notification system across group management features.

### Notes
- Consider displaying toast or badge indicators on the frontend for new role changes or approvals.
- Broadcast support can be added later for real-time updates.