### PR TITLE
build: send notifications on group join and join request submission

### DIFF
--- a/app/Http/Controllers/JoinGroupController.php
+++ b/app/Http/Controllers/JoinGroupController.php
@@ -30,25 +30,26 @@ final class JoinGroupController extends Controller
 
         if ($group->auto_approval) {
             GroupUser::create([
-                'group_id'   => $group->id,
-                'user_id'    => $user->id,
-                'status'     => GroupUserStatusEnum::APPROVED->value,
-                'role'       => GroupUserRoleEnum::USER->value,
+                'group_id' => $group->id,
+                'user_id' => $user->id,
+                'status' => GroupUserStatusEnum::APPROVED->value,
+                'role' => GroupUserRoleEnum::USER->value,
                 'owner_id' => $user->id,
             ]);
 
             $user->notify(new GroupJoined($group->name));
         } else {
             GroupUser::create([
-                'group_id'   => $group->id,
-                'user_id'    => $user->id,
-                'status'     => GroupUserStatusEnum::PENDING->value,
-                'role'       => GroupUserRoleEnum::USER->value,
+                'group_id' => $group->id,
+                'user_id' => $user->id,
+                'status' => GroupUserStatusEnum::PENDING->value,
+                'role' => GroupUserRoleEnum::USER->value,
                 'owner_id' => $user->id,
             ]);
 
             $group->adminUsers->each->notify(new RequestToJoinGroup($group->name, $user->name));
         }
+
         return back();
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\GroupUserRoleEnum;
 use App\Enums\GroupUserStatusEnum;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
@@ -92,5 +93,12 @@ final class Group extends Model implements HasMedia
         return $this->belongsToMany(User::class, 'group_users')
             ->wherePivotNull('token')
             ->wherePivot('status', GroupUserStatusEnum::PENDING->value);
+    }
+
+    public function adminUsers()
+    {
+        return $this->belongsToMany(User::class, 'group_users')
+            ->wherePivot('role', GroupUserRoleEnum::ADMIN->value)
+            ->withPivot(['status', 'role', 'group_id', 'owner_id']);
     }
 }

--- a/app/Notifications/GroupJoined.php
+++ b/app/Notifications/GroupJoined.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class GroupJoined extends Notification implements ShouldQueue
+final class GroupJoined extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -16,8 +17,7 @@ class GroupJoined extends Notification implements ShouldQueue
      */
     public function __construct(
         public string $groupName,
-    )
-    {
+    ) {
         //
     }
 

--- a/app/Notifications/GroupJoined.php
+++ b/app/Notifications/GroupJoined.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class GroupJoined extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $groupName,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => "You joined {$this->groupName}!",
+        ];
+    }
+}

--- a/app/Notifications/RequestToJoinGroup.php
+++ b/app/Notifications/RequestToJoinGroup.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class RequestToJoinGroup extends Notification implements ShouldQueue
+final class RequestToJoinGroup extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -17,8 +18,7 @@ class RequestToJoinGroup extends Notification implements ShouldQueue
     public function __construct(
         public string $groupName,
         public string $userName,
-    )
-    {
+    ) {
         //
     }
 

--- a/app/Notifications/RequestToJoinGroup.php
+++ b/app/Notifications/RequestToJoinGroup.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class RequestToJoinGroup extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $groupName,
+        public string $userName,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => "User {$this->userName} request to join the group {$this->groupName}",
+        ];
+    }
+}

--- a/app/Notifications/UserRoleChanged.php
+++ b/app/Notifications/UserRoleChanged.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class UserRoleChanged extends Notification implements ShouldQueue
+final class UserRoleChanged extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -17,8 +18,7 @@ class UserRoleChanged extends Notification implements ShouldQueue
     public function __construct(
         public string $groupName,
         public string $role
-    )
-    {
+    ) {
         //
     }
 


### PR DESCRIPTION
### What
- Implemented notifications when a user **joins a group** (either via auto-approval or manual approval).
- Implemented notifications to **group admins** when a user submits a **join request**.
- Ensured all notifications are queued to prevent request delay.
- Applied Pint for code formatting consistency.

### Why
- Keeps group admins informed when new members request access.
- Notifies relevant users about successful joins to reinforce feedback and engagement.
