### PR TITLE
refactor(notifications): pass target params to support navigation to related entities

### DIFF
--- a/app/Http/Controllers/ApproveJoinRequestController.php
+++ b/app/Http/Controllers/ApproveJoinRequestController.php
@@ -25,7 +25,7 @@ final class ApproveJoinRequestController extends Controller
              * @var User $user
              */
             $user = $groupUser->user;
-            $user->notify(new JoinRequestApproved($group->name));
+            $user->notify(new JoinRequestApproved($group));
         } else {
             $groupUser->delete();
         }

--- a/app/Http/Controllers/ChangeUserRoleController.php
+++ b/app/Http/Controllers/ChangeUserRoleController.php
@@ -36,7 +36,7 @@ final class ChangeUserRoleController extends Controller
              * @var User $user
              */
             $user = $groupUser->user;
-            $user->notify(new UserRoleChanged($group->name, $data['role']));
+            $user->notify(new UserRoleChanged($group, $data['role']));
         }
 
         return back();

--- a/app/Http/Controllers/InviteUserController.php
+++ b/app/Http/Controllers/InviteUserController.php
@@ -37,7 +37,7 @@ final class InviteUserController extends Controller
             'owner_id' => Auth::id(),
         ]);
 
-        $invitee->notify(new InvitationToGroup($group->name, $hours));
+        $invitee->notify(new InvitationToGroup($group, $hours));
 
         return back()->with('success',
             __('Invitation send to :email', [

--- a/app/Http/Controllers/JoinGroupController.php
+++ b/app/Http/Controllers/JoinGroupController.php
@@ -37,7 +37,7 @@ final class JoinGroupController extends Controller
                 'owner_id' => $user->id,
             ]);
 
-            $user->notify(new GroupJoined($group->name));
+            $user->notify(new GroupJoined($group));
         } else {
             GroupUser::create([
                 'group_id' => $group->id,
@@ -47,7 +47,7 @@ final class JoinGroupController extends Controller
                 'owner_id' => $user->id,
             ]);
 
-            $group->adminUsers->each->notify(new RequestToJoinGroup($group->name, $user->name));
+            $group->adminUsers->each->notify(new RequestToJoinGroup($group, $user->name));
         }
 
         return back();

--- a/app/Notifications/GroupJoined.php
+++ b/app/Notifications/GroupJoined.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications;
 
+use App\Models\Group;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -16,7 +17,7 @@ final class GroupJoined extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public string $groupName,
+        public Group $group,
     ) {
         //
     }
@@ -39,7 +40,8 @@ final class GroupJoined extends Notification implements ShouldQueue
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => "You joined {$this->groupName}!",
+            'message' => "You joined {$this->group->name}!",
+            'target_params' => ['group' => $this->group->slug]
         ];
     }
 }

--- a/app/Notifications/InvitationToGroup.php
+++ b/app/Notifications/InvitationToGroup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications;
 
+use App\Models\Group;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -16,7 +17,7 @@ final class InvitationToGroup extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public string $groupName,
+        public Group $group,
         public int $expiresInHours
     ) {
         //
@@ -40,9 +41,8 @@ final class InvitationToGroup extends Notification implements ShouldQueue
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => "You have been invited to join the group {$this->groupName}",
-            'expires_in' => $this->expiresInHours,
-            'group_name' => $this->groupName,
+            'message' => "You have been invited to join the group {$this->group->name}. Invitation link expires in {$this->expiresInHours} hours.",
+            'target_params' => ['group' => $this->group->slug]
         ];
     }
 }

--- a/app/Notifications/JoinRequestApproved.php
+++ b/app/Notifications/JoinRequestApproved.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications;
 
+use App\Models\Group;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -16,7 +17,7 @@ final class JoinRequestApproved extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public string $groupName
+        public Group $group
     ) {
         //
     }
@@ -39,7 +40,8 @@ final class JoinRequestApproved extends Notification implements ShouldQueue
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => "Your request to join {$this->groupName} has been approved.",
+            'message' => "Your request to join {$this->group->name} has been approved.",
+            'target_params' => ['group' => $this->group->slug]
         ];
     }
 }

--- a/app/Notifications/RequestToJoinGroup.php
+++ b/app/Notifications/RequestToJoinGroup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications;
 
+use App\Models\Group;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -16,7 +17,7 @@ final class RequestToJoinGroup extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public string $groupName,
+        public Group $group,
         public string $userName,
     ) {
         //
@@ -40,7 +41,8 @@ final class RequestToJoinGroup extends Notification implements ShouldQueue
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => "User {$this->userName} request to join the group {$this->groupName}",
+            'message' => "User {$this->userName} request to join the group {$this->group->name}",
+            'target_params' => ['group' => $this->group->slug]
         ];
     }
 }

--- a/app/Notifications/UserRoleChanged.php
+++ b/app/Notifications/UserRoleChanged.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications;
 
+use App\Models\Group;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -16,7 +17,7 @@ final class UserRoleChanged extends Notification implements ShouldQueue
      * Create a new notification instance.
      */
     public function __construct(
-        public string $groupName,
+        public Group $group,
         public string $role
     ) {
         //
@@ -40,7 +41,8 @@ final class UserRoleChanged extends Notification implements ShouldQueue
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => "Your role in this group {$this->groupName} has been changed to {$this->role}",
+            'message' => "Your role in this group {$this->group->name} has been changed to {$this->role}",
+            'target_params' => ['group' => $this->group->slug]
         ];
     }
 }


### PR DESCRIPTION
### What
- Refactored group notifications to include `target` parameters (`group-slug`) in their `data` payload.

### Why
- Enables clickable notifications that take the user directly to relevant sections of the app.