### PR TITLE
build: track who added a user to a group with `created_by` column

### DIFF
--- a/app/Http/Controllers/GroupInvitationController.php
+++ b/app/Http/Controllers/GroupInvitationController.php
@@ -26,7 +26,7 @@ final class GroupInvitationController extends Controller
             ->where('token', $token)
             ->first();
 
-        if (!$groupUser) {
+        if (! $groupUser) {
             return response()->json([
                 'message' => 'This invitation token is invalid.',
             ], 404);
@@ -35,7 +35,7 @@ final class GroupInvitationController extends Controller
         return Inertia::render('Group/GroupInvitationAccept', [
             'group' => [
                 'name' => $groupUser->group->name,
-                'id' => $groupUser->group->id
+                'id' => $groupUser->group->id,
             ],
             'token' => $groupUser->token,
         ]);
@@ -56,7 +56,8 @@ final class GroupInvitationController extends Controller
             'role' => GroupUserRoleEnum::USER,
             'token' => $token,
             'token_expires_at' => now()->addHours($hours),
-            'owner_id' => Auth::id(),
+            'owner_id' => $group->user_id,
+            'created_by' => Auth::id()
         ]);
 
         $invitee->notify(new InvitationToGroup($group, $groupUser, $hours));
@@ -75,7 +76,7 @@ final class GroupInvitationController extends Controller
          */
         $groupUser = GroupUser::where('token', $token)->first();
 
-        if (!$groupUser) {
+        if (! $groupUser) {
             return response()->json([
                 'message' => 'The invitation link is not valid.',
             ], 404);

--- a/app/Http/Controllers/JoinGroupController.php
+++ b/app/Http/Controllers/JoinGroupController.php
@@ -33,7 +33,8 @@ final class JoinGroupController extends Controller
                 'user_id' => $user->id,
                 'status' => GroupUserStatusEnum::APPROVED->value,
                 'role' => GroupUserRoleEnum::USER->value,
-                'owner_id' => $user->id,
+                'owner_id' => $group->user_id,
+                'created_by' => $user->id
             ]);
 
             $user->notify(new GroupJoined($group));
@@ -43,7 +44,8 @@ final class JoinGroupController extends Controller
                 'user_id' => $user->id,
                 'status' => GroupUserStatusEnum::PENDING->value,
                 'role' => GroupUserRoleEnum::USER->value,
-                'owner_id' => $user->id,
+                'owner_id' => $group->user_id,
+                'created_by' => $user->id
             ]);
 
             $group->adminUsers->each->notify(new RequestToJoinGroup($group, $user->name));

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read DateTimeInterface $token_expires_at
  * @property-read DateTimeInterface $token_used
  * @property-read int $owner_id
+ * @property-read int $created_by
  * @property-read int $user_id
  * @property-read int $group_id
  * @property-read DateTimeInterface $created_at
@@ -40,9 +41,9 @@ final class GroupUser extends Model
         return $this->belongsTo(User::class, 'owner_id');
     }
 
-    public function user(): BelongsTo
+    public function creator(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'created_by');
     }
 
     public function group(): BelongsTo

--- a/app/Services/GroupService.php
+++ b/app/Services/GroupService.php
@@ -8,6 +8,7 @@ use App\Enums\GroupUserRoleEnum;
 use App\Enums\GroupUserStatusEnum;
 use App\Models\Group;
 use App\Models\GroupUser;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 final class GroupService
@@ -24,6 +25,7 @@ final class GroupService
                 'user_id' => $userId,
                 'group_id' => $group->id,
                 'owner_id' => $group->user_id,
+                'created_by' => Auth::id()
             ]);
 
             $group->setRelation('pivot', $groupUser);

--- a/database/migrations/2025_08_08_183124_add_created_by_to_group_users_table.php
+++ b/database/migrations/2025_08_08_183124_add_created_by_to_group_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('group_users', function (Blueprint $table) {
+            $table->foreignId('created_by')->after('owner_id')->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('group-users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,8 +7,8 @@ use App\Http\Controllers\ChangeUserRoleController;
 use App\Http\Controllers\CommentController;
 use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupImageController;
-use App\Http\Controllers\HomeController;
 use App\Http\Controllers\GroupInvitationController;
+use App\Http\Controllers\HomeController;
 use App\Http\Controllers\JoinGroupController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\PostAttachmentController;
@@ -51,7 +51,6 @@ Route::middleware('auth')->group(function () {
             Route::patch('change-role', ChangeUserRoleController::class)->name('change-role');
             Route::delete('users', RemoveUserFromGroupController::class)->name('users.remove');
         });
-
 
     Route::get('groups/invitations/accept/{token}', [GroupInvitationController::class, 'show'])->name('groups.invitations.show');
     Route::post('groups/invitations/accept/{token}', [GroupInvitationController::class, 'accept'])->name('groups.invitations.accept');


### PR DESCRIPTION
### What
- Added a `created_by` column to the `group_users` pivot table via a new migration.
- Updated group member addition logic to assign the authenticated user ID to `created_by` when a new `GroupUser` record is created.
- Applied Pint code formatting.

### Why
- Helps distinguish between users who joined via invitation, request, or were added by an admin/owner.
- Enables future features like audit trails, member management insights, and invitation tracking.
- Provides clarity and accountability in group management.

### Notes
- Consider exposing this data in the `GroupUser` resource for future use in admin UIs or logs.