### PR TITLE
feat(policy): add Post and Comment authorization rules for groups

### DIFF
--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -22,6 +22,23 @@ final class CommentPolicy
      */
     public function delete(User $user, Comment $comment): bool
     {
-        return $user->id === $comment->user_id;
+        if ($user->id === $comment->user_id) {
+            return true;
+        }
+
+        if ($comment->post->group) {
+            $group = $comment->post->group;
+            $author = $comment->user;
+
+            if ($group->owner_id === $user->id) {
+                return true;
+            }
+
+            if ($group->isAdmin($user) && !$group->isAdmin($author)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -22,6 +22,23 @@ final class PostPolicy
      */
     public function delete(User $user, Post $post): bool
     {
-        return $user->id === $post->user_id;
+        if ($user->id === $post->user_id) {
+            return true;
+        }
+
+        if ($post->group) {
+            $group = $post->group;
+            $author = $post->user;
+
+            if ($group->user_id === $user->id) {
+                return true;
+            }
+
+            if ($group->isAdmin($user) && !$group->isAdmin($author)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
### What

- Implemented PostPolicy and CommentPolicy to handle permissions within groups.
- Only group owners can delete other admins' posts or comments.
- Normal admins can manage content of non-admin users but cannot delete each other's content.
- Updated resource responses to include `can` attributes for frontend checks.