### PR TITLE
feat: implement post pinning for user and group profiles

### DIFF
--- a/app/Http/Controllers/PinPostController.php
+++ b/app/Http/Controllers/PinPostController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class PinPostController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request, Post $post)
+    {
+        $scope = $request->get('scope', 'user');
+
+        return $scope === 'group'
+            ? $this->toggleGroupPin($post)
+            : $this->toggleUserPin($request->user(), $post);
+    }
+
+    private function toggleGroupPin(Post $post)
+    {
+        /**
+         * @var Group $group
+         */
+        $group = $post->group;
+        /**
+         * @var User $user
+         */
+        $user = Auth::user();
+
+        if (! $group) {
+            return response('Invalid Request', 400);
+        }
+
+        if (! $group->isAdmin($user)) {
+            return response("You don't have permission to access this page.", 403);
+        }
+
+        $pinned = $group->pinned_post_id !== $post->id;
+        $group->update([
+            'pinned_post_id' => $pinned ? $post->id : null,
+        ]);
+
+        return back()
+            ->with('success', __("Post was successfully " . ($pinned ? 'pinned' : 'unpinned')));
+    }
+
+    private function toggleUserPin(User $user, Post $post)
+    {
+        $pinned = $user->pinned_post_id !== $post->id;
+        $user->update([
+            'pinned_post_id' => $pinned ? $post->id : null,
+        ]);
+
+        return back()
+            ->with('success', __("Post was successfully " . ($pinned ? 'pinned' : 'unpinned')));
+    }
+}

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Resources\GroupResource;
@@ -9,9 +11,8 @@ use App\Models\Group;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Inertia\Inertia;
 
-class SearchController extends Controller
+final class SearchController extends Controller
 {
     /**
      * Handle the incoming request.
@@ -25,18 +26,18 @@ class SearchController extends Controller
         }
 
         $users = User::query()
-            ->where('name', 'like', '%' . $request->search . '%')
-            ->orWhere('username', 'like', '%' . $request->search . '%')
+            ->where('name', 'like', '%'.$request->search.'%')
+            ->orWhere('username', 'like', '%'.$request->search.'%')
             ->latest()
             ->paginate(7);
 
         $posts = Post::query()
-            ->where('body', 'like', '%' . $request->search . '%')
+            ->where('body', 'like', '%'.$request->search.'%')
             ->latest()
             ->paginate(7);
 
         $groups = Group::query()
-            ->where('name', 'like', '%' . $request->search . '%')
+            ->where('name', 'like', '%'.$request->search.'%')
             ->latest()
             ->paginate(7);
 

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -24,6 +24,10 @@ final class PostResource extends JsonResource
          */
         $post = $this->resource;
         $comments = $this->comments;
+        $user = Auth::user();
+
+        $isPinnedByUser = $user->pinned_post_id && $user->pinned_post_id === $post->id;
+        $isPinnedByGroup = $post->group && $post->group->pinned_post_id && $post->group->pinned_post_id === $post->id;
 
         return [
             'id' => $post->id,
@@ -36,9 +40,12 @@ final class PostResource extends JsonResource
             'group' => GroupResource::make($post->group),
             'comments' => CommentResource::collection($comments),
             'num_of_comments' => count($comments),
+            'isPinned' => $isPinnedByUser || $isPinnedByGroup,
             'can' => [
                 'update' => Gate::allows('update', $post),
                 'delete' => Gate::allows('delete', $post),
+                'pin' => Gate::allows('pin', $post),
+                'pinToGroup' => Gate::allows('pinToGroup', $post),
             ],
         ];
     }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Group;
 use App\Models\Post;
 use App\Models\User;
 
@@ -40,5 +41,27 @@ final class PostPolicy
         }
 
         return false;
+    }
+
+    public function pintToGroup(?User $user, Post $post): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        /**
+         * @var Group $group
+         */
+        $group = $post->group;
+        if (! $group) {
+            return false;
+        }
+
+        return $group->isAdmin($user);
+    }
+
+    public function pin(?User $user): bool
+    {
+        return $user !== null;
     }
 }

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -15,8 +15,11 @@ export interface Post {
     comments: Comment[];
     group?: Group;
     attachments: Attachment[];
+    isPinned: boolean;
     can: {
         update: boolean;
         delete: boolean;
+        pin: boolean;
+        pinToGroup: boolean;
     };
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupImageController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\PinPostController;
 use App\Http\Controllers\PostAttachmentController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
@@ -35,6 +36,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/attachments/{media}/download', [PostAttachmentController::class, 'download'])->name('attachments.download');
 
     Route::resource('posts', PostController::class);
+    Route::post('/posts/{post}/pin', PinPostController::class)->name('posts.pin');
     Route::resource('posts.comments', CommentController::class)
         ->only(['store'])
         ->shallow();


### PR DESCRIPTION
### What
- Implemented `PinPostController` to handle pin/unpin actions.  
- Added route for post pinning.  
- Defined permissions to control who can pin posts.  
- Extended `PostResource` to include pin-related data.  

### Why
- Enables users and group admins to highlight important posts.  
- Ensures pinning is secure with permission checks.  
- Provides consistent API response for pinned posts. 